### PR TITLE
fix: drop binary-presence check from lightpanda driver validate

### DIFF
--- a/lib/wallabidi/lightpanda.ex
+++ b/lib/wallabidi/lightpanda.ex
@@ -278,11 +278,10 @@ defmodule Wallabidi.Lightpanda do
   end
 
   defp lightpanda_available? do
-    mod = Module.concat([Lightpanda])
-
-    Code.ensure_loaded?(mod) and
-      is_binary(apply(mod, :bin_path, [])) and
-      File.exists?(apply(mod, :bin_path, []))
+    # The Lightpanda module from the Hex dep ships a lazy installer
+    # (`Lightpanda.ensure_installed!/0`); the binary is downloaded on
+    # first session start, so the dep being loaded is enough.
+    Code.ensure_loaded?(Lightpanda)
   rescue
     _ -> false
   end


### PR DESCRIPTION
## Summary
- Lightpanda 0.2.10-rc.1 lazy-installs the binary on first \`Lightpanda.Server\` start (via \`Lightpanda.ensure_installed!/0\`).
- Wallabidi's driver validation was still raising "can't find lightpanda" at app boot because it required \`File.exists?(Lightpanda.bin_path/0)\` — which is false until lazy install kicks in.
- This was the only thing failing CI on main after the lightpanda bump (commit 2bfada8). Drop the file check.

## Test plan
- [ ] CI Lightpanda matrix row passes without an explicit \`mix lightpanda.install\` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)