### PR TITLE
fix: exclude bidi-server node_modules from Hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -88,7 +88,21 @@ defmodule Wallabidi.Mixfile do
 
   defp package do
     [
-      files: ["lib", "mix.exs", "README.md", "LICENSE.md", "priv"],
+      # Don't ship priv/bidi-server/node_modules — consumers run `npm install`
+      # via `mix wallabidi.install` after pulling the package. Including
+      # node_modules pushes the tarball past Hex's 8 MB limit.
+      files: [
+        "lib",
+        "mix.exs",
+        "README.md",
+        "LICENSE.md",
+        "priv/cdp",
+        "priv/perf-matrix.svg",
+        "priv/run_command.sh",
+        "priv/bidi-server/package.json",
+        "priv/bidi-server/package-lock.json",
+        "priv/bidi-server/run.mjs"
+      ],
       maintainers: @maintainers,
       licenses: ["MIT"],
       links: %{


### PR DESCRIPTION
## Summary
- v0.2.14 publish failed validation: tarball >8 MB. \`priv/bidi-server/node_modules\` is 43 MB.
- Consumers fetch node_modules themselves via \`mix wallabidi.install\` (which runs \`npm install\` in \`priv/bidi-server/\`), so we don't need to ship them.
- Replace the wholesale \`priv\` entry in \`package.files\` with explicit sub-paths.
- \`mix hex.build\` now produces a 168 KB tarball.

## Plan after merge
- Move \`v0.2.14\` tag to the post-merge commit (we're republishing 0.2.14, not bumping to 0.2.15).
- \`mix hex.publish\` v0.2.14.

## Test plan
- [ ] CI green
- [ ] \`mix hex.build\` locally produces a tarball under 8 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)