### PR TITLE
docs: refresh perf numbers (LV-subset, apples-to-apples)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Wallabidi is a fork of [Wallaby](https://github.com/elixir-wallaby/wallaby) with
 
 ## Drivers
 
-| Driver | Speed | What it does | When to use |
-|--------|-------|-------------|-------------|
-| **LiveView** | ~0ms/test | Renders pages in-process via Phoenix.ConnTest. No browser. | Default for local dev — instant feedback |
-| **Lightpanda** | ~50ms/test | Headless JS-capable browser via CDP. No CSS rendering. | Fast path for full functional suites — nearly LiveView speed |
-| **Chrome (CDP)** | ~200ms/test | Full browser via Chrome DevTools Protocol. Real multi-threading via Chrome's per-target threads. | Full fidelity (CSS, screenshots, mouse). Best concurrent throughput today. |
-| **Chrome (BiDi)** | ~600ms/test | Full browser via WebDriver BiDi (chromium-bidi → Chrome). Cross-engine portable. | Future-proof choice as BiDi matures; aspirationally replaces CDP. |
+| Driver | Per-test (peak concurrency) | What it does | When to use |
+|--------|-----------------------------|-------------|-------------|
+| **LiveView** | ~145ms | Renders pages in-process via Phoenix.ConnTest. No browser. | Default for local dev — fastest feedback |
+| **Lightpanda** | ~234ms | Headless JS-capable browser via CDP. No CSS rendering. | Full functional suites — close to LiveView once parallelized |
+| **Chrome (CDP)** | ~379ms | Full browser via Chrome DevTools Protocol. Real multi-threading via Chrome's per-target threads. | Full fidelity (CSS, screenshots, mouse). Best concurrent throughput today. |
+| **Chrome (BiDi)** | ~2.07s | Full browser via WebDriver BiDi (chromium-bidi → Chrome). Cross-engine portable. | Future-proof choice as BiDi matures; aspirationally replaces CDP. |
+
+Numbers are wall-time per test on a 16-thread M-series Mac, running the LV-runnable subset (124 tests) so each driver runs the same workload. Each driver was benchmarked at its recommended `--max-cases` (LV/LP=mc8, CDP=mc8, BiDi=mc2). See [the concurrency-and-performance section](#concurrency-and-performance) for the full matrix.
 
 Tests declare their minimum requirement with tags:
 
@@ -46,35 +48,35 @@ Each test runs on the **cheapest driver** that supports it. No env vars, no alia
 
 ## Concurrency and performance
 
-Each driver scales differently with `--max-cases`. The values below come from running the integration suite end-to-end on a 16-thread Mac laptop (M-series, all suites passing at the listed concurrency).
+Each driver scales differently with `--max-cases`. The values below come from running the LV-runnable subset of the integration suite (124 tests, the same workload on every driver) end-to-end on a 16-thread M-series Mac. All four drivers passed cleanly.
 
 ![per-test wall time vs max-cases](priv/perf-matrix.svg)
 
-Wall time in seconds for the full integration suite at each `--max-cases`:
+Wall time in seconds at each `--max-cases`, with each driver running the same 124-test workload:
 
-| Driver         | mc1   | mc2   | mc4   | mc8     | mc16    | Tests |
-|----------------|-------|-------|-------|---------|---------|-------|
-| **BiDi** (Chrome)  | 917s  | 690s  | —     | —       | —       | 285   |
-| **CDP** (Chrome)   | 421s  | 240s  | **175s** | 148s ⚠ | 144s ⚠ | 289   |
-| **Lightpanda**     | 140s  | 84s   | 49s   | 34s     | **30s** | 153   |
-| **LiveView**       | 122s  | 78s   | 42s   | 28s     | **25s** | 124   |
+| Driver           | mc1  | mc2  | mc4   | mc8     | mc16    |
+|------------------|------|------|-------|---------|---------|
+| **BiDi** (Chrome)    | 362s | 256s | 239s  | —       | —       |
+| **CDP** (Chrome)     | 161s | 93s  | 64s   | **47s** | 48s     |
+| **Lightpanda**       | 128s | 75s  | 50s   | **29s** | 29s     |
+| **LiveView**         | 112s | 63s  | 32s   | 21s     | **18s** |
 
-⚠ = passes mostly but introduces 1–2 flaky failures from concurrency contention.
+Each driver also runs tests that the others skip — Lightpanda runs `:headless`-tagged tests, Chrome runs `:browser`-tagged ones (screenshots, file uploads, etc.). The full per-driver workload is larger; numbers above are the apples-to-apples subset.
 
 **Recommended `--max-cases` per driver:**
 
 | Driver | Recommended | Why |
 |--------|-------------|-----|
-| **BiDi** | `2` | chromium-bidi's BiDi Mapper is single-threaded JS in one Chrome tab. Each pool slot adds another Chrome+Mapper, so concurrency = pool size. Benchmarked up to 2; higher is possible. |
-| **CDP** | `4` | CDP's flat-session protocol multiplexes parallel work across Chrome's per-target threads. mc4 is the sweet spot — beyond it you save ~30s and pick up flakes. |
-| **Lightpanda** | `16` | In-process, scales near-linearly with BEAM concurrency. |
+| **BiDi** | `2` | chromium-bidi's BiDi Mapper is single-threaded JS in one Chrome tab. Each pool slot adds another Chrome+Mapper, so concurrency = pool size. mc4 only buys ~7% over mc2. |
+| **CDP** | `8` | CDP's flat-session protocol multiplexes parallel work across Chrome's per-target threads. mc8 is the sweet spot — past it the cost stops dropping. |
+| **Lightpanda** | `8` | Per-session WebSocket server overhead means in-process advantages plateau at mc8. |
 | **LiveView** | `16` | No external process; just BEAM. Use as much concurrency as ExUnit allows. |
 
 **When to pick which driver in CI:**
 
-- *Default:* let wallabidi route each test to the cheapest driver that supports it. Most LiveView-app tests run on the LiveView driver and are nearly free.
-- *JS-heavy app:* Lightpanda at mc16 — fastest real headless option.
-- *Need full browser fidelity (CSS, screenshots, mouse events):* CDP at mc4.
+- *Default:* let wallabidi route each test to the cheapest driver that supports it. LV-supported tests run on the LiveView driver and are the cheapest.
+- *JS-heavy app:* Lightpanda at mc8 — fastest real headless option.
+- *Need full browser fidelity (CSS, screenshots, mouse events):* CDP at mc8.
 - *Cross-browser portability or BiDi spec features:* BiDi at mc2. Slower than CDP today because the BiDi protocol serializes through a single Mapper per Chrome; will improve as chromium-bidi or successor implementations add parallel mapping.
 
 ## Why fork?

--- a/integration_test/cases/browser/navigation_test.exs
+++ b/integration_test/cases/browser/navigation_test.exs
@@ -1,5 +1,5 @@
 defmodule Wallabidi.Integration.Browser.NavigationTest do
-  use Wallabidi.Integration.SessionCase, async: false
+  use Wallabidi.Integration.SessionCase, async: true
 
   test "navigating by path only", %{session: session} do
     visit(session, "page_1.html")

--- a/priv/perf-matrix.svg
+++ b/priv/perf-matrix.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 420" width="720" height="420" font-family="-apple-system, system-ui, sans-serif">
 <rect width="720" height="420" fill="white"/>
-<text x="70" y="20" font-size="14" font-weight="600" fill="#111">Per-test wall time vs --max-cases</text>
+<text x="70" y="20" font-size="14" font-weight="600" fill="#111">Per-test wall time vs --max-cases (LV-runnable subset, 124 tests)</text>
 <line x1="70" y1="30" x2="70" y2="370" stroke="#999" stroke-width="1"/>
 <line x1="70" y1="370" x2="540" y2="370" stroke="#999" stroke-width="1"/>
 <line x1="70.0" y1="370" x2="70.0" y2="375" stroke="#999"/>
@@ -17,35 +17,36 @@
 <line x1="65" y1="370.0" x2="70" y2="370.0" stroke="#999"/>
 <text x="62" y="374.0" text-anchor="end" font-size="11" fill="#444">0.00s</text>
 <line x1="65" y1="285.0" x2="70" y2="285.0" stroke="#999"/>
-<text x="62" y="289.0" text-anchor="end" font-size="11" fill="#444">0.85s</text>
+<text x="62" y="289.0" text-anchor="end" font-size="11" fill="#444">0.75s</text>
 <line x1="65" y1="200.0" x2="70" y2="200.0" stroke="#999"/>
-<text x="62" y="204.0" text-anchor="end" font-size="11" fill="#444">1.70s</text>
+<text x="62" y="204.0" text-anchor="end" font-size="11" fill="#444">1.50s</text>
 <line x1="65" y1="115.0" x2="70" y2="115.0" stroke="#999"/>
-<text x="62" y="119.0" text-anchor="end" font-size="11" fill="#444">2.54s</text>
+<text x="62" y="119.0" text-anchor="end" font-size="11" fill="#444">2.25s</text>
 <line x1="65" y1="30.0" x2="70" y2="30.0" stroke="#999"/>
-<text x="62" y="34.0" text-anchor="end" font-size="11" fill="#444">3.39s</text>
+<text x="62" y="34.0" text-anchor="end" font-size="11" fill="#444">3.00s</text>
 <text x="20" y="200.0" text-anchor="middle" font-size="12" fill="#222" transform="rotate(-90 20 200.0)">seconds per test</text>
-<path d="M70.0,47.05014749262534 L187.5,127.28613569321536" stroke="#7c3aed" stroke-width="2" fill="none"/>
-<circle cx="70.0" cy="47.05014749262534" r="3.5" fill="#7c3aed"/>
-<circle cx="187.5" cy="127.28613569321536" r="3.5" fill="#7c3aed"/>
-<path d="M70.0,223.56932153392333 L187.5,286.7551622418879 L305.0,308.8200589970501 L422.5,318.8495575221239 L540.0,319.8525073746313" stroke="#2563eb" stroke-width="2" fill="none"/>
-<circle cx="70.0" cy="223.56932153392333" r="3.5" fill="#2563eb"/>
-<circle cx="187.5" cy="286.7551622418879" r="3.5" fill="#2563eb"/>
-<circle cx="305.0" cy="308.8200589970501" r="3.5" fill="#2563eb"/>
-<circle cx="422.5" cy="318.8495575221239" r="3.5" fill="#2563eb"/>
-<circle cx="540.0" cy="319.8525073746313" r="3.5" fill="#2563eb"/>
-<path d="M70.0,277.7286135693215 L187.5,314.83775811209443 L305.0,337.905604719764 L422.5,347.93510324483776 L540.0,349.94100294985253" stroke="#10b981" stroke-width="2" fill="none"/>
-<circle cx="70.0" cy="277.7286135693215" r="3.5" fill="#10b981"/>
-<circle cx="187.5" cy="314.83775811209443" r="3.5" fill="#10b981"/>
-<circle cx="305.0" cy="337.905604719764" r="3.5" fill="#10b981"/>
-<circle cx="422.5" cy="347.93510324483776" r="3.5" fill="#10b981"/>
-<circle cx="540.0" cy="349.94100294985253" r="3.5" fill="#10b981"/>
-<path d="M70.0,271.71091445427726 L187.5,306.8141592920354 L305.0,335.89970501474926 L422.5,346.9321533923304 L540.0,349.94100294985253" stroke="#f59e0b" stroke-width="2" fill="none"/>
-<circle cx="70.0" cy="271.71091445427726" r="3.5" fill="#f59e0b"/>
-<circle cx="187.5" cy="306.8141592920354" r="3.5" fill="#f59e0b"/>
-<circle cx="305.0" cy="335.89970501474926" r="3.5" fill="#f59e0b"/>
-<circle cx="422.5" cy="346.9321533923304" r="3.5" fill="#f59e0b"/>
-<circle cx="540.0" cy="349.94100294985253" r="3.5" fill="#f59e0b"/>
+<path d="M70.0,39.17999999999999 L187.5,135.9666666666667 L305.0,151.60666666666665" stroke="#7c3aed" stroke-width="2" fill="none"/>
+<circle cx="70.0" cy="39.17999999999999" r="3.5" fill="#7c3aed"/>
+<circle cx="187.5" cy="135.9666666666667" r="3.5" fill="#7c3aed"/>
+<circle cx="305.0" cy="151.60666666666665" r="3.5" fill="#7c3aed"/>
+<path d="M70.0,222.89333333333335 L187.5,285.0 L305.0,311.52 L422.5,327.0466666666667 L540.0,326.14" stroke="#2563eb" stroke-width="2" fill="none"/>
+<circle cx="70.0" cy="222.89333333333335" r="3.5" fill="#2563eb"/>
+<circle cx="187.5" cy="285.0" r="3.5" fill="#2563eb"/>
+<circle cx="305.0" cy="311.52" r="3.5" fill="#2563eb"/>
+<circle cx="422.5" cy="327.0466666666667" r="3.5" fill="#2563eb"/>
+<circle cx="540.0" cy="326.14" r="3.5" fill="#2563eb"/>
+<path d="M70.0,253.04000000000002 L187.5,301.43333333333334 L305.0,324.32666666666665 L422.5,343.48 L540.0,343.48" stroke="#10b981" stroke-width="2" fill="none"/>
+<circle cx="70.0" cy="253.04000000000002" r="3.5" fill="#10b981"/>
+<circle cx="187.5" cy="301.43333333333334" r="3.5" fill="#10b981"/>
+<circle cx="305.0" cy="324.32666666666665" r="3.5" fill="#10b981"/>
+<circle cx="422.5" cy="343.48" r="3.5" fill="#10b981"/>
+<circle cx="540.0" cy="343.48" r="3.5" fill="#10b981"/>
+<path d="M70.0,267.65999999999997 L187.5,312.4266666666667 L305.0,340.76 L422.5,350.84666666666664 L540.0,353.56666666666666" stroke="#f59e0b" stroke-width="2" fill="none"/>
+<circle cx="70.0" cy="267.65999999999997" r="3.5" fill="#f59e0b"/>
+<circle cx="187.5" cy="312.4266666666667" r="3.5" fill="#f59e0b"/>
+<circle cx="305.0" cy="340.76" r="3.5" fill="#f59e0b"/>
+<circle cx="422.5" cy="350.84666666666664" r="3.5" fill="#f59e0b"/>
+<circle cx="540.0" cy="353.56666666666666" r="3.5" fill="#f59e0b"/>
 <line x1="558" y1="40" x2="578" y2="40" stroke="#7c3aed" stroke-width="2"/>
 <circle cx="568" cy="40" r="3.5" fill="#7c3aed"/>
 <text x="584" y="44" font-size="11" fill="#222">BiDi (Chrome)</text>


### PR DESCRIPTION
## Summary
- Reruns the full perf matrix with every driver running the same 124-test LV-runnable subset, so per-test cost is directly comparable across rows.
- Flips \`navigation_test.exs\` from \`async: false\` to \`async: true\` — those two read-only \`visit page_1.html\` tests didn't need to be serial. Drops LV mc16 from 25s to 18s.
- Regenerates \`priv/perf-matrix.svg\` with the new numbers.
- Updates the Drivers table to use per-test (peak concurrency) numbers and adds a clarifying paragraph about apples-to-apples vs. per-driver workload.

## New numbers (16-thread M-series Mac, 124 tests)

| Driver       | mc1  | mc2  | mc4  | mc8  | mc16 |
|--------------|------|------|------|------|------|
| BiDi         | 362s | 256s | 239s |  —   |  —   |
| CDP          | 161s |  93s |  64s |  47s |  48s |
| Lightpanda   | 128s |  75s |  50s |  29s |  29s |
| LiveView     | 112s |  63s |  32s |  21s |  18s |

Per-test cost at each driver's recommended max-cases: LV ~145ms, LP ~234ms, CDP ~379ms, BiDi ~2.07s.

## Other changes worth noting

- Recommended max-cases for CDP and Lightpanda bumped from 4/16 to 8/8 — cost stops dropping past mc8 for both.
- BiDi recommended stays at 2 (mc4 only buys ~7%).

## Supersedes
- Closes #13.

## Test plan
- [ ] CI green
- [ ] Render the SVG and confirm it looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)