### PR TITLE
test: bump V2Driver cookies round-trip slow budget

### DIFF
--- a/integration_test/cases/v2/v2_driver_test.exs
+++ b/integration_test/cases/v2/v2_driver_test.exs
@@ -71,6 +71,7 @@ defmodule Wallabidi.Integration.V2.DriverTest do
       assert html =~ ~r/<html/i
     end
 
+    @tag slow: 6_000
     test "cookies round-trip", %{session: session} do
       base = Application.fetch_env!(:wallabidi, :base_url)
       :ok = V2Driver.visit(session, base <> "index.html")


### PR DESCRIPTION
Trips the 4s SlowTestGuard budget on GHA runners (~4.1s observed). Bump to 6s. Same shape as the other CI-runner-variance budget bumps.