### PR TITLE
fix(browser): make await_patch actually wait

### DIFF
--- a/integration_test/cases/chrome/await_patch_test.exs
+++ b/integration_test/cases/chrome/await_patch_test.exs
@@ -77,6 +77,7 @@ defmodule Wallabidi.Integration.AwaitPatchTest do
   end
 
   describe "await_patch (explicit)" do
+    @tag slow: 8_000
     test "standalone await_patch waits for next patch", %{session: session, live_url: url} do
       session
       |> visit("#{url}/counter")
@@ -86,9 +87,60 @@ defmodule Wallabidi.Integration.AwaitPatchTest do
       |> await_patch()
       |> assert_has(Query.css("#count", text: "1"))
     end
+
+    # Stronger test: schedule a DELAYED broadcast (~300ms), then
+    # `await_patch()`, then read DOM via execute_script WITHOUT the
+    # assert_has retry fallback. The delay ensures the patch can't
+    # land before `await_patch` is called. If `await_patch` is a no-op,
+    # it returns immediately, the script reads stale "waiting" DOM, and
+    # the assertion fails. If `await_patch` actually blocks until the
+    # PubSub-triggered patch lands, the script reads "received".
+    #
+    # This is the exact use case the @doc example advertises:
+    # "Wait for a PubSub-triggered update."
+    test "await_patch blocks for an external (PubSub) trigger", %{
+      session: session,
+      live_url: url
+    } do
+      session = visit(session, "#{url}/pubsub")
+
+      # Wait until subscribe runs (connected mount completes).
+      assert_has(session, Query.css("#message", text: "waiting"))
+
+      # Broadcast from a different process AFTER a delay so the patch
+      # is guaranteed to arrive after `await_patch` is called.
+      test_pid = self()
+
+      spawn(fn ->
+        Process.sleep(300)
+
+        Phoenix.PubSub.broadcast(
+          Wallabidi.Integration.PubSub,
+          "pubsub_live",
+          {:new_message, "received"}
+        )
+
+        send(test_pid, :broadcast_sent)
+      end)
+
+      # await_patch should block until the LV applies the diff.
+      session = await_patch(session)
+
+      # Confirm the broadcast actually fired by now (sanity).
+      assert_received :broadcast_sent
+
+      # Read DOM SYNCHRONOUSLY — no retry. If await_patch returned
+      # before the patch was applied, this sees "waiting".
+      execute_script(
+        session,
+        "return document.getElementById('message').textContent",
+        fn value -> assert value == "received" end
+      )
+    end
   end
 
   describe "async LiveView updates" do
+    @tag slow: 8_000
     test "await_patch catches async result after start_async", %{session: session, live_url: url} do
       session
       |> visit("#{url}/async")

--- a/lib/wallabidi/browser.ex
+++ b/lib/wallabidi/browser.ex
@@ -1870,20 +1870,18 @@ defmodule Wallabidi.Browser do
       |> assert_has(Query.css(".updated"))
   """
   @spec await_patch(session, keyword()) :: session
-  def await_patch(%Session{} = session, opts \\ []) do
-    if live_view_aware?(session) do
-      timeout = Keyword.get(opts, :timeout, 5_000)
-
-      case Wallabidi.Remote.LiveViewAware.prepare_patch(session) do
-        :prepared -> Wallabidi.Remote.LiveViewAware.await_patch(session, timeout)
-        :no_liveview -> :ok
-      end
-    end
-
+  def await_patch(%Session{driver: driver} = session, opts \\ []) do
+    driver.await_patch(session, opts)
     session
   end
 
-  # Any session that has a protocol adapter can run JS → LiveView-aware.
+  # Legacy predicate. The `:protocol` field is never populated by any
+  # driver, so this is permanently false — `fill_in`'s drain calc and
+  # `with_patch_await`'s patch/navigate orchestration both fall through
+  # to their else branches. Kept here to avoid spreading the cleanup
+  # beyond `await_patch/2`; see also the per-driver `click_aware`
+  # paths in the CDP/BiDi clients that already handle their own
+  # patch-awaiting.
   defp live_view_aware?(%Session{protocol: mod}) when not is_nil(mod), do: true
   defp live_view_aware?(_), do: false
 

--- a/lib/wallabidi/driver.ex
+++ b/lib/wallabidi/driver.ex
@@ -37,6 +37,20 @@ defmodule Wallabidi.Driver do
   @optional_callbacks release_server_session: 1
 
   @doc """
+  Wait for the next LiveView DOM patch on the session.
+
+  Remote drivers (CDP, BiDi, Lightpanda) implement this by arming a
+  JS-side promise on `liveSocket.main.domCallbacks.onPatchEnd` and
+  racing it against the configured timeout. The in-process
+  `Wallabidi.LiveView.Driver` renders synchronously, so for that
+  driver this is a no-op.
+
+  See `Wallabidi.Browser.await_patch/2` for the public-facing
+  contract.
+  """
+  @callback await_patch(Session.t(), keyword()) :: :ok
+
+  @doc """
   Invoked to accept one alert triggered within `open_dialog_fn` and return the alert message.
   """
   @callback accept_alert(Session.t(), open_dialog_fn) :: String.t()

--- a/lib/wallabidi/live_view/driver.ex
+++ b/lib/wallabidi/live_view/driver.ex
@@ -83,6 +83,12 @@ defmodule Wallabidi.LiveView.Driver do
 
   # --- Navigation ---
 
+  # In-process LV renders are synchronous — every interaction returns
+  # with the post-event DOM already applied. There's nothing to wait
+  # for, so `await_patch` is a no-op.
+  @impl true
+  def await_patch(_session, _opts), do: :ok
+
   @impl true
   def visit(session, url) do
     # Browser.visit may pass a full URL (base_url + path). Extract just the path.

--- a/lib/wallabidi/remote/drivers/chrome_bidi.ex
+++ b/lib/wallabidi/remote/drivers/chrome_bidi.ex
@@ -28,6 +28,7 @@ defmodule Wallabidi.Remote.Drivers.ChromeBiDi do
   alias Wallabidi.{Element, Session}
   alias Wallabidi.Remote.BiDi.Client, as: BiDiClient
   alias Wallabidi.Remote.BiDi.WebSocketClient
+  alias Wallabidi.Remote.LiveViewAware
   alias Wallabidi.Remote.Transport.BiDi
   alias Wallabidi.Remote.Transport.Protocol
 
@@ -159,6 +160,11 @@ defmodule Wallabidi.Remote.Drivers.ChromeBiDi do
     result = check_logs!(session, fn -> BiDiClient.visit(session, url) end)
     _ = await_liveview_connected_v2(session)
     result
+  end
+
+  @impl true
+  def await_patch(%Session{} = session, opts) do
+    LiveViewAware.arm_and_await(session, Keyword.get(opts, :timeout, 5_000))
   end
 
   # Mirrors V2ChromeDriver.await_liveview_connected_v2/1 and

--- a/lib/wallabidi/remote/drivers/chrome_cdp.ex
+++ b/lib/wallabidi/remote/drivers/chrome_cdp.ex
@@ -155,6 +155,11 @@ defmodule Wallabidi.Remote.Drivers.ChromeCDP do
   end
 
   @impl true
+  def await_patch(%Session{} = session, opts) do
+    LiveViewAware.arm_and_await(session, Keyword.get(opts, :timeout, 5_000))
+  end
+
+  @impl true
   def current_url(%Session{} = session), do: CDPClient.current_url(session)
 
   @impl true

--- a/lib/wallabidi/remote/drivers/lightpanda_cdp.ex
+++ b/lib/wallabidi/remote/drivers/lightpanda_cdp.ex
@@ -216,6 +216,11 @@ defmodule Wallabidi.Remote.Drivers.LightpandaCDP do
   end
 
   @impl true
+  def await_patch(%Session{} = session, opts) do
+    LiveViewAware.arm_and_await(session, Keyword.get(opts, :timeout, 5_000))
+  end
+
+  @impl true
   def current_url(%Session{} = session), do: CDPClient.current_url(session)
 
   @impl true

--- a/lib/wallabidi/remote/live_view_aware.ex
+++ b/lib/wallabidi/remote/live_view_aware.ex
@@ -107,6 +107,24 @@ defmodule Wallabidi.Remote.LiveViewAware do
   end
 
   @doc """
+  One-shot: arm a fresh patch promise, then await it. Returns `:ok`
+  whether the patch arrives, the page navigates, the timer elapses,
+  or there's no LiveView on the page — callers of this helper want
+  "best-effort wait for the next patch" semantics.
+
+  Used by `Wallabidi.Browser.await_patch/2` via the driver behaviour.
+  """
+  @spec arm_and_await(Session.t(), timeout()) :: :ok
+  def arm_and_await(%Session{} = session, timeout) do
+    case prepare_patch(session) do
+      :prepared -> _ = await_patch(session, timeout)
+      :no_liveview -> :ok
+    end
+
+    :ok
+  end
+
+  @doc """
   Waits until no LiveView patch has arrived for `idle_ms` ms, or the
   overall `timeout` elapses. Used after `fill_in` where multiple
   phx-change events fire and we want to wait for the final one.


### PR DESCRIPTION
## Summary

\`Browser.await_patch/2\` has been a no-op for every session since the V2 driver promotion. The internal gate \`live_view_aware?\` required \`session.protocol\` to be non-nil, but no driver populates that field anymore. Users calling \`await_patch\` after a \`Phoenix.PubSub.broadcast\` (the exact example in the docstring) got an immediate return rather than a wait for the resulting DOM patch.

Existing tests didn't catch it because \`assert_has\`'s retry budget made things appear to work — the test passed because the patch arrived during the retry window, not because \`await_patch\` actually waited.

## The fix

Promotes \`await_patch\` to a \`Wallabidi.Driver\` behaviour callback. Each driver declares its own implementation:

| Driver | Implementation |
|---|---|
| \`ChromeCDP\` / \`ChromeBiDi\` / \`LightpandaCDP\` | delegate to \`LiveViewAware.arm_and_await/2\` |
| \`Wallabidi.LiveView.Driver\` | no-op (in-process renders are synchronous) |

\`Browser.await_patch\` becomes a 3-line delegate. No driver-list switch in \`Browser\`.

## TDD shape

New test at \`await_patch_test.exs:101\` uses a delayed PubSub broadcast to deterministically distinguish actually-waiting from returning-immediately-and-assert_has-retried:

\`\`\`elixir
test \"await_patch blocks for an external (PubSub) trigger\" do
  spawn(fn ->
    Process.sleep(300)
    Phoenix.PubSub.broadcast(..., {:new_message, \"received\"})
    send(test_pid, :broadcast_sent)
  end)

  session = await_patch(session)
  assert_received :broadcast_sent  # fails if await_patch returned early

  execute_script(session, \"return document.getElementById('message').textContent\",
    fn value -> assert value == \"received\" end)  # synchronous, no retry
end
\`\`\`

This test fails on the broken \`await_patch\` and passes on the fix.

## What this PR does NOT do

The audit also flagged that \`fill_in\`'s patch drain calc and \`with_patch_await\`'s click classification path use the same broken predicate. Those are kept untouched here to scope this PR to the public API contract of \`await_patch\`. Sorting out \`with_patch_await\` (which duplicates work the per-driver \`click_aware\` already does) is a follow-up.

## Test plan

- [x] \`mix format\` clean
- [x] \`mix credo --strict\` clean (0 issues)
- [x] \`mix test\` (unit): 159/159 pass
- [x] \`mix test.chrome integration_test/cases/chrome/await_patch_test.exs\`: 25/25 pass (was 24/25 + 1 silently-no-op + 0 distinguishing the bug)
- [x] LP live_view_smoke: 13/13 pass
- [x] LV-driver live_view_smoke: 13/13 pass
- [ ] CI: full driver matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)