### PR TITLE
refactor(transport): extract shared state machine into Transport.Common

### DIFF
--- a/lib/wallabidi/remote/transport/bidi/session_actor.ex
+++ b/lib/wallabidi/remote/transport/bidi/session_actor.ex
@@ -7,21 +7,13 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
   #
   # The actor's lifetime IS the session's lifetime: it monitors the
   # WSC and its owner, and tears down both when either dies.
-  #
-  # ## Phase A scope
-  #
-  # This is the minimal first pass — it implements the synchronous
-  # passthrough surface (get_session, cdp_send/cast, subscribe,
-  # sync_barrier, frame stack, page id/state) so the V2BiDiDriver can
-  # be wired up end-to-end. Page-load awaits and bootstrap channel
-  # routing (find/page_ready) are stubbed and will be filled in by
-  # Phases B and C.
 
   use GenServer
 
   require Logger
 
   alias Wallabidi.Remote.BiDi.WebSocketClient
+  alias Wallabidi.Remote.Transport.Common
 
   defstruct [
     :ws_pid,
@@ -30,20 +22,16 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
     :owner_ref,
     :session,
     :teardown_fun,
-    page_id: nil,
     frame_stack: [],
     frame_contexts: %{},
-    # Page-load bookkeeping (Phase B). `loads` buffers
-    # `%{navigation_id => %{milestone_name => true}}` for events that
-    # arrived before any caller asked. `load_waiters` is a list of
+    # `%{navigation_id => %{milestone_name => true}}` for load events
+    # that arrived before any caller asked, plus a waiter list of
     # `{from, navigation_id_or_:any, milestone_name, timer_ref}`.
     loads: %{},
     load_waiters: [],
-    # Bootstrap channel bookkeeping (Phase C). Each find_waiter is
-    # keyed by query_id, valued by `{:pending, timer_ref, from_or_nil}`
-    # or `{:resolved, result}` once the bootstrap channel has fired.
+    # Each find_waiter is keyed by query_id, valued by
+    # `{:pending, timer_ref, from_or_nil}` or `{:resolved, result}`.
     find_waiters: %{},
-    # The most recent pageId reported by the bootstrap.
     last_page_id: nil,
     # `{from, pre_page_id, timer_ref}` when someone's awaiting a
     # page_ready transition; `nil` otherwise.
@@ -194,31 +182,16 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
 
   def handle_call(:sync_barrier, _from, state), do: {:reply, :ok, state}
 
-  def handle_call(:get_page_id, _from, state),
-    do: {:reply, state.page_id, state}
-
-  def handle_call(:get_page_state, _from, state),
-    do: {:reply, {:lv_ready, []}, state}
-
   def handle_call(:current_context_id, _from, state) do
-    case state.frame_stack do
-      [] -> {:reply, nil, state}
-      [top | _] -> {:reply, top, state}
-    end
+    {:reply, Common.current_context_id(state), state}
   end
 
   def handle_call({:push_frame, context_id}, _from, state) do
-    {:reply, :ok, %{state | frame_stack: [context_id | state.frame_stack]}}
+    {:reply, :ok, Common.push_frame(state, context_id)}
   end
 
   def handle_call(:pop_frame, _from, state) do
-    stack =
-      case state.frame_stack do
-        [] -> []
-        [_ | rest] -> rest
-      end
-
-    {:reply, :ok, %{state | frame_stack: stack}}
+    {:reply, :ok, Common.pop_frame(state)}
   end
 
   # Pop and return the head value, so the driver can switch the
@@ -234,11 +207,11 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
     do: {:reply, :ok, %{state | frame_stack: []}}
 
   def handle_call({:record_frame_context, frame_id, context_id}, _from, state) do
-    {:reply, :ok, %{state | frame_contexts: Map.put(state.frame_contexts, frame_id, context_id)}}
+    {:reply, :ok, Common.record_frame_context(state, frame_id, context_id)}
   end
 
   def handle_call({:lookup_frame_context, frame_id}, _from, state) do
-    {:reply, Map.get(state.frame_contexts, frame_id), state}
+    {:reply, Common.lookup_frame_context(state, frame_id), state}
   end
 
   def handle_call({:update_browsing_context, _session_id, target_id}, _from, state) do
@@ -278,34 +251,15 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
   # ----- Bootstrap channel (Phase C) -----
 
   def handle_call({:await_page_ready_after, pre_page_id, timeout_ms}, from, state) do
-    if pre_page_id != nil and state.last_page_id != nil and
-         state.last_page_id != pre_page_id do
-      {:reply, :ok, state}
-    else
-      timer_ref = Process.send_after(self(), {:page_ready_timeout, from}, timeout_ms)
-      {:noreply, %{state | page_ready_waiter: {from, pre_page_id, timer_ref}}}
-    end
+    Common.await_page_ready_after(state, pre_page_id, timeout_ms, from)
   end
 
   def handle_call({:register_find, query_id, timeout_ms}, _from, state) do
-    timer_ref = Process.send_after(self(), {:find_timeout, query_id}, timeout_ms)
-    waiters = Map.put(state.find_waiters, query_id, {:pending, timer_ref, nil})
-    {:reply, :ok, %{state | find_waiters: waiters}}
+    {:reply, :ok, Common.register_find(state, query_id, timeout_ms)}
   end
 
   def handle_call({:await_find_result, query_id}, from, state) do
-    case Map.get(state.find_waiters, query_id) do
-      {:resolved, result} ->
-        waiters = Map.delete(state.find_waiters, query_id)
-        {:reply, result, %{state | find_waiters: waiters}}
-
-      {:pending, timer_ref, nil} ->
-        waiters = Map.put(state.find_waiters, query_id, {:pending, timer_ref, from})
-        {:noreply, %{state | find_waiters: waiters}}
-
-      nil ->
-        {:reply, {:timeout, 0}, state}
-    end
+    Common.await_find_result(state, query_id, from)
   end
 
   # ----- Cast -----
@@ -344,7 +298,7 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
 
     if params["channel"] == "__wallabidi" do
       payload = get_in(params, ["data", "value"]) || ""
-      {:noreply, route_channel_payload(state, payload)}
+      {:noreply, Common.route_bootstrap_payload(state, payload)}
     else
       {:noreply, state}
     end
@@ -357,32 +311,11 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
   end
 
   def handle_info({:find_timeout, query_id}, state) do
-    case Map.pop(state.find_waiters, query_id) do
-      {nil, _} ->
-        {:noreply, state}
-
-      {{:resolved, _}, _rest} ->
-        # Already resolved — keep the entry; the awaiter will pop it.
-        {:noreply, state}
-
-      {{:pending, _ref, nil}, rest} ->
-        {:noreply, %{state | find_waiters: rest}}
-
-      {{:pending, _ref, from}, rest} ->
-        GenServer.reply(from, {:timeout, 0})
-        {:noreply, %{state | find_waiters: rest}}
-    end
+    {:noreply, Common.handle_find_timeout(state, query_id)}
   end
 
   def handle_info({:page_ready_timeout, from}, state) do
-    case state.page_ready_waiter do
-      {^from, _pre, _ref} ->
-        GenServer.reply(from, :timeout)
-        {:noreply, %{state | page_ready_waiter: nil}}
-
-      _ ->
-        {:noreply, state}
-    end
+    {:noreply, Common.handle_page_ready_timeout(state, from)}
   end
 
   def handle_info({:page_load_timeout, from}, state) do
@@ -462,56 +395,6 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
   # bootstrap) and dispatch to find_waiters or page_ready_waiter.
   # Format mirrors the legacy SessionProcess decoder so the bootstrap
   # JS doesn't need a BiDi-specific variant.
-  defp route_channel_payload(state, payload) when is_binary(payload) do
-    case Jason.decode(payload) do
-      {:ok, %{"id" => query_id, "error" => err}} when is_binary(err) ->
-        resolve_find(state, query_id, {:error, :invalid_selector})
-
-      {:ok, %{"id" => query_id, "count" => count} = msg} ->
-        resolve_find(state, query_id, {:ok, count, msg["meta"]})
-
-      {:ok, %{"type" => "page_ready", "pageId" => page_id}} ->
-        state = %{state | last_page_id: page_id}
-        wake_page_ready_waiter(state, page_id)
-
-      _ ->
-        state
-    end
-  end
-
-  defp route_channel_payload(state, _), do: state
-
-  defp resolve_find(state, query_id, result) do
-    case Map.get(state.find_waiters, query_id) do
-      nil ->
-        state
-
-      {:pending, timer_ref, nil} ->
-        Process.cancel_timer(timer_ref)
-        %{state | find_waiters: Map.put(state.find_waiters, query_id, {:resolved, result})}
-
-      {:pending, timer_ref, from} ->
-        Process.cancel_timer(timer_ref)
-        GenServer.reply(from, result)
-        %{state | find_waiters: Map.delete(state.find_waiters, query_id)}
-
-      {:resolved, _} ->
-        state
-    end
-  end
-
-  defp wake_page_ready_waiter(state, page_id) do
-    case state.page_ready_waiter do
-      {from, pre_page_id, timer_ref} when pre_page_id != page_id ->
-        Process.cancel_timer(timer_ref)
-        GenServer.reply(from, :ok)
-        %{state | page_ready_waiter: nil}
-
-      _ ->
-        state
-    end
-  end
-
   # Wake any waiter whose (navigation_id, milestone) matches — or
   # whose loader is the `:any` wildcard (await_next_page_load).
   # If no waiter is registered, buffer the milestone so a later

--- a/lib/wallabidi/remote/transport/common.ex
+++ b/lib/wallabidi/remote/transport/common.ex
@@ -1,0 +1,210 @@
+defmodule Wallabidi.Remote.Transport.Common do
+  @moduledoc false
+
+  # Shared per-session state-machine helpers used by all three Transport
+  # actors:
+  #
+  #   * `Wallabidi.Remote.Transport.Session` (Chrome CDP, shared WS)
+  #   * `Wallabidi.Remote.Transport.PerSession.Actor` (Lightpanda, per-session WS)
+  #   * `Wallabidi.Remote.Transport.BiDi.SessionActor` (Chrome BiDi, per-session WS)
+  #
+  # Each actor owns its own wire protocol (CDP/BiDi) and connection model
+  # (shared vs per-session WS), but they all maintain the same waiter
+  # state machine for find / page-load / page-ready / frame tracking.
+  # Centralising that here keeps the three implementations from drifting.
+
+  # ----- Find waiters -----
+
+  @doc """
+  Registers a find query with an in-flight timeout. The caller will
+  subsequently call `await_find_result/1` and either get the resolved
+  result or a `:timeout` once the timer fires.
+  """
+  @spec register_find(map(), term(), non_neg_integer()) :: map()
+  def register_find(state, query_id, timeout_ms) do
+    timer_ref = Process.send_after(self(), {:find_timeout, query_id}, timeout_ms)
+    %{state | find_waiters: Map.put(state.find_waiters, query_id, {:pending, timer_ref, nil})}
+  end
+
+  @doc """
+  Looks up a registered find result, suspending the caller if not yet
+  resolved. Returns `{:reply, ...}` / `{:noreply, ...}` shapes ready to
+  return from `handle_call/3`.
+  """
+  @spec await_find_result(map(), term(), GenServer.from()) ::
+          {:reply, term(), map()} | {:noreply, map()}
+  def await_find_result(state, query_id, from) do
+    case Map.get(state.find_waiters, query_id) do
+      {:resolved, result} ->
+        {:reply, result, %{state | find_waiters: Map.delete(state.find_waiters, query_id)}}
+
+      {:pending, timer_ref, nil} ->
+        waiters = Map.put(state.find_waiters, query_id, {:pending, timer_ref, from})
+        {:noreply, %{state | find_waiters: waiters}}
+
+      nil ->
+        {:reply, {:timeout, 0}, state}
+    end
+  end
+
+  @doc """
+  Resolves a registered find with a result. If a caller is already
+  awaiting, replies immediately and drops the entry; otherwise stashes
+  the result for an arriving caller and cancels the pending timer.
+  """
+  @spec resolve_find(map(), term(), term()) :: map()
+  def resolve_find(state, query_id, result) do
+    case Map.get(state.find_waiters, query_id) do
+      nil ->
+        state
+
+      {:resolved, _} ->
+        state
+
+      {:pending, timer_ref, nil} ->
+        Process.cancel_timer(timer_ref)
+        %{state | find_waiters: Map.put(state.find_waiters, query_id, {:resolved, result})}
+
+      {:pending, timer_ref, from} ->
+        Process.cancel_timer(timer_ref)
+        GenServer.reply(from, result)
+        %{state | find_waiters: Map.delete(state.find_waiters, query_id)}
+    end
+  end
+
+  @doc """
+  Handles a `{:find_timeout, query_id}` message — drops the pending entry
+  and replies `:timeout` to any awaiter. Resolved entries are kept (the
+  awaiter will pop them via `await_find_result/3`).
+  """
+  @spec handle_find_timeout(map(), term()) :: map()
+  def handle_find_timeout(state, query_id) do
+    case Map.get(state.find_waiters, query_id) do
+      nil ->
+        state
+
+      {:resolved, _} ->
+        state
+
+      {:pending, _ref, nil} ->
+        %{state | find_waiters: Map.delete(state.find_waiters, query_id)}
+
+      {:pending, _ref, from} ->
+        GenServer.reply(from, {:timeout, 0})
+        %{state | find_waiters: Map.delete(state.find_waiters, query_id)}
+    end
+  end
+
+  # ----- Page-ready waiter -----
+
+  @doc """
+  Suspends or replies based on whether a new pageId has already arrived
+  relative to `pre_page_id`. Returns a handle_call-shaped tuple.
+  """
+  @spec await_page_ready_after(map(), term() | nil, non_neg_integer(), GenServer.from()) ::
+          {:reply, :ok, map()} | {:noreply, map()}
+  def await_page_ready_after(state, pre_page_id, timeout_ms, from) do
+    if pre_page_id != nil and state.last_page_id != nil and
+         state.last_page_id != pre_page_id do
+      {:reply, :ok, state}
+    else
+      timer_ref = Process.send_after(self(), {:page_ready_timeout, from}, timeout_ms)
+      {:noreply, %{state | page_ready_waiter: {from, pre_page_id, timer_ref}}}
+    end
+  end
+
+  @doc """
+  Records the most recent pageId and wakes any waiter whose `pre_page_id`
+  differs (i.e. a transition has occurred).
+  """
+  @spec update_last_page_id(map(), term()) :: map()
+  def update_last_page_id(state, page_id) do
+    state = %{state | last_page_id: page_id}
+
+    case state.page_ready_waiter do
+      {from, pre_page_id, timer_ref} when pre_page_id != page_id ->
+        Process.cancel_timer(timer_ref)
+        GenServer.reply(from, :ok)
+        %{state | page_ready_waiter: nil}
+
+      _ ->
+        state
+    end
+  end
+
+  @doc """
+  Handles a `{:page_ready_timeout, from}` message. Replies `:timeout` only
+  if the waiter is still the one named in the message.
+  """
+  @spec handle_page_ready_timeout(map(), GenServer.from()) :: map()
+  def handle_page_ready_timeout(state, from) do
+    case state.page_ready_waiter do
+      {^from, _pre, _ref} ->
+        GenServer.reply(from, :timeout)
+        %{state | page_ready_waiter: nil}
+
+      _ ->
+        state
+    end
+  end
+
+  # ----- Frame stack -----
+
+  @doc "Pushes a context_id (or browsing-context-id) onto the frame stack."
+  @spec push_frame(map(), term()) :: map()
+  def push_frame(state, context_id) do
+    %{state | frame_stack: [context_id | state.frame_stack]}
+  end
+
+  @doc "Pops the top entry off the frame stack, leaving an empty stack alone."
+  @spec pop_frame(map()) :: map()
+  def pop_frame(state) do
+    case state.frame_stack do
+      [] -> state
+      [_ | rest] -> %{state | frame_stack: rest}
+    end
+  end
+
+  @doc "Returns the current frame's context id (top of stack) or nil."
+  @spec current_context_id(map()) :: term() | nil
+  def current_context_id(state), do: List.first(state.frame_stack)
+
+  @doc "Stores a `frame_id => context_id` mapping."
+  @spec record_frame_context(map(), term(), term()) :: map()
+  def record_frame_context(state, frame_id, context_id) do
+    %{state | frame_contexts: Map.put(state.frame_contexts, frame_id, context_id)}
+  end
+
+  @doc "Looks up a previously-recorded context id for a frame."
+  @spec lookup_frame_context(map(), term()) :: term() | nil
+  def lookup_frame_context(state, frame_id) do
+    Map.get(state.frame_contexts, frame_id)
+  end
+
+  # ----- Bootstrap channel payload routing -----
+
+  @doc """
+  Routes a JSON payload from the bootstrap channel (`__wallabidi(...)` in
+  CDP, `script.message` in BiDi) to the appropriate state-machine update.
+  Recognises find results and page_ready signals. Unknown payloads return
+  the state unchanged.
+  """
+  @spec route_bootstrap_payload(map(), binary()) :: map()
+  def route_bootstrap_payload(state, payload) when is_binary(payload) do
+    case Jason.decode(payload) do
+      {:ok, %{"id" => query_id, "error" => err}} when is_binary(err) ->
+        resolve_find(state, query_id, {:error, :invalid_selector})
+
+      {:ok, %{"id" => query_id, "count" => count} = msg} ->
+        resolve_find(state, query_id, {:ok, count, msg["meta"]})
+
+      {:ok, %{"type" => "page_ready", "pageId" => page_id}} ->
+        update_last_page_id(state, page_id)
+
+      _ ->
+        state
+    end
+  end
+
+  def route_bootstrap_payload(state, _), do: state
+end

--- a/lib/wallabidi/remote/transport/per_session/actor.ex
+++ b/lib/wallabidi/remote/transport/per_session/actor.ex
@@ -21,6 +21,8 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
   use GenServer
   require Logger
 
+  alias Wallabidi.Remote.Transport.Common
+
   defstruct [
     # ----- Connection state (was WebSocket) -----
     :conn,
@@ -196,69 +198,36 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
     {:reply, :ok, state}
   end
 
-  def handle_call(:get_page_state, _from, state) do
-    {:reply, {:lv_ready, []}, state}
-  end
-
   def handle_call({:register_find, query_id, timeout_ms}, _from, state) do
-    timeout_ref = Process.send_after(self(), {:find_timeout, query_id}, timeout_ms)
-    waiters = Map.put(state.find_waiters, query_id, {:pending, timeout_ref, nil})
-    {:reply, :ok, %{state | find_waiters: waiters}}
+    {:reply, :ok, Common.register_find(state, query_id, timeout_ms)}
   end
 
   def handle_call({:await_find_result, query_id}, from, state) do
-    case Map.get(state.find_waiters, query_id) do
-      {:resolved, result} ->
-        waiters = Map.delete(state.find_waiters, query_id)
-        {:reply, result, %{state | find_waiters: waiters}}
-
-      {:pending, timeout_ref, nil} ->
-        waiters = Map.put(state.find_waiters, query_id, {:pending, timeout_ref, from})
-        {:noreply, %{state | find_waiters: waiters}}
-
-      nil ->
-        {:reply, {:timeout, 0}, state}
-    end
-  end
-
-  def handle_call(:get_page_id, _from, state) do
-    {:reply, state.last_page_id, state}
+    Common.await_find_result(state, query_id, from)
   end
 
   def handle_call({:await_page_ready_after, pre_page_id, timeout_ms}, from, state) do
-    if pre_page_id != nil and state.last_page_id != nil and
-         state.last_page_id != pre_page_id do
-      {:reply, :ok, state}
-    else
-      timer_ref = Process.send_after(self(), {:page_ready_timeout, from}, timeout_ms)
-      {:noreply, %{state | page_ready_waiter: {from, pre_page_id, timer_ref}}}
-    end
+    Common.await_page_ready_after(state, pre_page_id, timeout_ms, from)
   end
 
   def handle_call(:current_context_id, _from, state) do
-    {:reply, List.first(state.frame_stack), state}
+    {:reply, Common.current_context_id(state), state}
   end
 
   def handle_call({:push_frame, context_id}, _from, state) do
-    {:reply, :ok, %{state | frame_stack: [context_id | state.frame_stack]}}
+    {:reply, :ok, Common.push_frame(state, context_id)}
   end
 
   def handle_call(:pop_frame, _from, state) do
-    new_stack =
-      case state.frame_stack do
-        [] -> []
-        [_ | rest] -> rest
-      end
-
-    {:reply, :ok, %{state | frame_stack: new_stack}}
+    {:reply, :ok, Common.pop_frame(state)}
   end
 
   def handle_call({:record_frame_context, frame_id, context_id}, _from, state) do
-    {:reply, :ok, %{state | frame_contexts: Map.put(state.frame_contexts, frame_id, context_id)}}
+    {:reply, :ok, Common.record_frame_context(state, frame_id, context_id)}
   end
 
   def handle_call({:lookup_frame_context, frame_id}, _from, state) do
-    {:reply, Map.get(state.frame_contexts, frame_id), state}
+    {:reply, Common.lookup_frame_context(state, frame_id), state}
   end
 
   @impl true
@@ -315,32 +284,11 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
   end
 
   defp handle_internal_message({:page_ready_timeout, from}, state) do
-    case state.page_ready_waiter do
-      {^from, _pre, _ref} ->
-        GenServer.reply(from, :timeout)
-        {:noreply, %{state | page_ready_waiter: nil}}
-
-      _ ->
-        {:noreply, state}
-    end
+    {:noreply, Common.handle_page_ready_timeout(state, from)}
   end
 
   defp handle_internal_message({:find_timeout, query_id}, state) do
-    case Map.get(state.find_waiters, query_id) do
-      nil ->
-        {:noreply, state}
-
-      {:resolved, _} ->
-        # Already resolved — keep the entry; await_find_result will pop it.
-        {:noreply, state}
-
-      {:pending, _ref, nil} ->
-        {:noreply, %{state | find_waiters: Map.delete(state.find_waiters, query_id)}}
-
-      {:pending, _ref, from} ->
-        GenServer.reply(from, {:timeout, 0})
-        {:noreply, %{state | find_waiters: Map.delete(state.find_waiters, query_id)}}
-    end
+    {:noreply, Common.handle_find_timeout(state, query_id)}
   end
 
   defp handle_internal_message({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state) do
@@ -472,7 +420,7 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
     params = Map.get(event, "params", %{})
 
     if params["name"] == "__wallabidi" and is_binary(params["payload"]) do
-      route_binding_payload(state, params["payload"])
+      Common.route_bootstrap_payload(state, params["payload"])
     else
       state
     end
@@ -513,58 +461,6 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
   defp buffer_load(state, loader_id, name) do
     loads = Map.update(state.loads, loader_id, %{name => true}, &Map.put(&1, name, true))
     %{state | loads: loads}
-  end
-
-  defp route_binding_payload(state, payload) do
-    case Jason.decode(payload) do
-      {:ok, %{"id" => query_id, "error" => err}} when is_binary(err) ->
-        resolve_find(state, query_id, {:error, :invalid_selector})
-
-      {:ok, %{"id" => query_id, "count" => count} = msg} ->
-        resolve_find(state, query_id, {:ok, count, msg["meta"]})
-
-      {:ok, %{"type" => "page_ready", "pageId" => page_id}} ->
-        update_last_page_id(state, page_id)
-
-      _ ->
-        state
-    end
-  end
-
-  defp update_last_page_id(state, page_id) do
-    state = %{state | last_page_id: page_id}
-    wake_page_ready_waiter(state, page_id)
-  end
-
-  defp wake_page_ready_waiter(state, page_id) do
-    case state.page_ready_waiter do
-      {from, pre_page_id, timer_ref} when pre_page_id != page_id ->
-        Process.cancel_timer(timer_ref)
-        GenServer.reply(from, :ok)
-        %{state | page_ready_waiter: nil}
-
-      _ ->
-        state
-    end
-  end
-
-  defp resolve_find(state, query_id, result) do
-    case Map.get(state.find_waiters, query_id) do
-      nil ->
-        state
-
-      {:pending, timeout_ref, nil} ->
-        Process.cancel_timer(timeout_ref)
-        %{state | find_waiters: Map.put(state.find_waiters, query_id, {:resolved, result})}
-
-      {:pending, timeout_ref, from} ->
-        Process.cancel_timer(timeout_ref)
-        GenServer.reply(from, result)
-        %{state | find_waiters: Map.delete(state.find_waiters, query_id)}
-
-      {:resolved, _} ->
-        state
-    end
   end
 
   defp wake_load_waiters(state, loader_id, name) do

--- a/lib/wallabidi/remote/transport/protocol.ex
+++ b/lib/wallabidi/remote/transport/protocol.ex
@@ -38,8 +38,6 @@ defmodule Wallabidi.Remote.Transport.Protocol do
   #     fires `__wallabidi(...)` for that query id.
   #   * `{:register_find, query_id, timeout_ms}` → reserves a
   #     find-waiter slot before the JS that fires the binding runs.
-  #   * `:get_page_id` → returns the most recent pageId or nil.
-  #   * `:get_page_state` → returns `{state_atom, history_list}`.
   #   * `:current_context_id` → returns the focused frame's
   #     executionContextId (or nil for root).
   #   * `{:push_frame, context_id}` / `:pop_frame` /
@@ -119,13 +117,6 @@ defmodule Wallabidi.Remote.Transport.Protocol do
     :exit, _ -> :timeout
   end
 
-  @spec get_page_id(Session.t()) :: String.t() | nil
-  def get_page_id(%Session{pid: pid}) when is_pid(pid) do
-    GenServer.call(pid, :get_page_id)
-  catch
-    :exit, _ -> nil
-  end
-
   @spec await_page_ready_after(Session.t(), String.t() | nil, timeout) :: :ok | :timeout
   def await_page_ready_after(%Session{pid: pid}, pre_page_id, timeout_ms \\ 5_000) do
     GenServer.call(pid, {:await_page_ready_after, pre_page_id, timeout_ms}, timeout_ms + 2_000)
@@ -197,13 +188,6 @@ defmodule Wallabidi.Remote.Transport.Protocol do
   end
 
   def sync_barrier(_), do: :ok
-
-  @spec get_page_state(Session.t()) :: {atom, list}
-  def get_page_state(%Session{pid: pid}) when is_pid(pid) do
-    GenServer.call(pid, :get_page_state)
-  catch
-    :exit, _ -> {:lv_ready, []}
-  end
 
   @spec stop(Session.t()) :: :ok
   def stop(%Session{pid: pid}) when is_pid(pid) do

--- a/lib/wallabidi/remote/transport/session.ex
+++ b/lib/wallabidi/remote/transport/session.ex
@@ -17,6 +17,7 @@ defmodule Wallabidi.Remote.Transport.Session do
   use GenServer
   require Logger
 
+  alias Wallabidi.Remote.Transport.Common
   alias Wallabidi.Remote.WebSocket
 
   defstruct [
@@ -214,19 +215,6 @@ defmodule Wallabidi.Remote.Transport.Session do
   def sync_barrier(%Wallabidi.Session{}), do: :ok
 
   @doc """
-  Returns `{state, history}` for diagnostic shape compatibility. The
-  bootstrap state machine isn't tracked here — returns a minimal
-  `{:lv_ready, []}` so callers (like `NavigationTimeoutError`) can
-  pattern-match on the shape without crashing.
-  """
-  @spec get_page_state(Wallabidi.Session.t()) :: {atom, list}
-  def get_page_state(%Wallabidi.Session{pid: pid}) when is_pid(pid) do
-    GenServer.call(pid, :get_page_state)
-  catch
-    :exit, _ -> {:lv_ready, []}
-  end
-
-  @doc """
   Register a find waiter (non-blocking). Must be called BEFORE the JS
   that triggers the binding, to avoid the race where the binding event
   arrives before the waiter is registered.
@@ -256,19 +244,6 @@ defmodule Wallabidi.Remote.Transport.Session do
     GenServer.call(pid, {:await_find_result, query_id}, timeout_ms + 2_000)
   catch
     :exit, _ -> {:timeout, 0}
-  end
-
-  @doc """
-  Returns the most-recent pageId reported by the bootstrap's
-  `page_ready` notification, or `nil` if the bootstrap hasn't yet
-  fired one. Capture this BEFORE a click that may navigate, then
-  pass it to `await_page_ready_after/3`.
-  """
-  @spec get_page_id(Wallabidi.Session.t()) :: String.t() | nil
-  def get_page_id(%Wallabidi.Session{pid: pid}) when is_pid(pid) do
-    GenServer.call(pid, :get_page_id)
-  catch
-    :exit, _ -> nil
   end
 
   @doc """
@@ -485,70 +460,36 @@ defmodule Wallabidi.Remote.Transport.Session do
     {:reply, :ok, state}
   end
 
-  def handle_call(:get_page_state, _from, state) do
-    {:reply, {:lv_ready, []}, state}
-  end
-
   def handle_call({:register_find, query_id, timeout_ms}, _from, state) do
-    timeout_ref = Process.send_after(self(), {:find_timeout, query_id}, timeout_ms)
-    waiters = Map.put(state.find_waiters, query_id, {:pending, timeout_ref, nil})
-    {:reply, :ok, %{state | find_waiters: waiters}}
+    {:reply, :ok, Common.register_find(state, query_id, timeout_ms)}
   end
 
   def handle_call({:await_find_result, query_id}, from, state) do
-    case Map.get(state.find_waiters, query_id) do
-      {:resolved, result} ->
-        waiters = Map.delete(state.find_waiters, query_id)
-        {:reply, result, %{state | find_waiters: waiters}}
-
-      {:pending, timeout_ref, nil} ->
-        waiters = Map.put(state.find_waiters, query_id, {:pending, timeout_ref, from})
-        {:noreply, %{state | find_waiters: waiters}}
-
-      nil ->
-        {:reply, {:timeout, 0}, state}
-    end
-  end
-
-  def handle_call(:get_page_id, _from, state) do
-    {:reply, state.last_page_id, state}
+    Common.await_find_result(state, query_id, from)
   end
 
   def handle_call({:await_page_ready_after, pre_page_id, timeout_ms}, from, state) do
-    # If we already have a different pageId, return :ok immediately.
-    if pre_page_id != nil and state.last_page_id != nil and
-         state.last_page_id != pre_page_id do
-      {:reply, :ok, state}
-    else
-      timer_ref = Process.send_after(self(), {:page_ready_timeout, from}, timeout_ms)
-      {:noreply, %{state | page_ready_waiter: {from, pre_page_id, timer_ref}}}
-    end
+    Common.await_page_ready_after(state, pre_page_id, timeout_ms, from)
   end
 
   def handle_call(:current_context_id, _from, state) do
-    {:reply, List.first(state.frame_stack), state}
+    {:reply, Common.current_context_id(state), state}
   end
 
   def handle_call({:push_frame, context_id}, _from, state) do
-    {:reply, :ok, %{state | frame_stack: [context_id | state.frame_stack]}}
+    {:reply, :ok, Common.push_frame(state, context_id)}
   end
 
   def handle_call(:pop_frame, _from, state) do
-    new_stack =
-      case state.frame_stack do
-        [] -> []
-        [_ | rest] -> rest
-      end
-
-    {:reply, :ok, %{state | frame_stack: new_stack}}
+    {:reply, :ok, Common.pop_frame(state)}
   end
 
   def handle_call({:record_frame_context, frame_id, context_id}, _from, state) do
-    {:reply, :ok, %{state | frame_contexts: Map.put(state.frame_contexts, frame_id, context_id)}}
+    {:reply, :ok, Common.record_frame_context(state, frame_id, context_id)}
   end
 
   def handle_call({:lookup_frame_context, frame_id}, _from, state) do
-    {:reply, Map.get(state.frame_contexts, frame_id), state}
+    {:reply, Common.lookup_frame_context(state, frame_id), state}
   end
 
   @impl true
@@ -603,7 +544,7 @@ defmodule Wallabidi.Remote.Transport.Session do
     params = Map.get(event, "params", %{})
 
     if params["name"] == "__wallabidi" and is_binary(params["payload"]) do
-      {:noreply, route_binding_payload(state, params["payload"])}
+      {:noreply, Common.route_bootstrap_payload(state, params["payload"])}
     else
       {:noreply, state}
     end
@@ -665,32 +606,11 @@ defmodule Wallabidi.Remote.Transport.Session do
   end
 
   def handle_info({:page_ready_timeout, from}, state) do
-    case state.page_ready_waiter do
-      {^from, _pre, _ref} ->
-        GenServer.reply(from, :timeout)
-        {:noreply, %{state | page_ready_waiter: nil}}
-
-      _ ->
-        {:noreply, state}
-    end
+    {:noreply, Common.handle_page_ready_timeout(state, from)}
   end
 
   def handle_info({:find_timeout, query_id}, state) do
-    case Map.get(state.find_waiters, query_id) do
-      nil ->
-        {:noreply, state}
-
-      {:resolved, _} ->
-        # Already resolved — keep the entry; await_find_result will pop it.
-        {:noreply, state}
-
-      {:pending, _ref, nil} ->
-        {:noreply, %{state | find_waiters: Map.delete(state.find_waiters, query_id)}}
-
-      {:pending, _ref, from} ->
-        GenServer.reply(from, {:timeout, 0})
-        {:noreply, %{state | find_waiters: Map.delete(state.find_waiters, query_id)}}
-    end
+    {:noreply, Common.handle_find_timeout(state, query_id)}
   end
 
   def handle_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state) do
@@ -727,70 +647,6 @@ defmodule Wallabidi.Remote.Transport.Session do
       Map.update(state.loads, loader_id, %{name => true}, &Map.put(&1, name, true))
 
     %{state | loads: loads}
-  end
-
-  # The bootstrap calls `__wallabidi(JSON.stringify(...))` with payloads
-  # like `%{"id" => query_id, "count" => N}` (find result) or
-  # `%{"type" => "page_ready", "pageId" => ...}` (page-ready signal).
-  # Find waiters key on the JSON `id` field; other shapes will get
-  # routed to their own handlers as we add them.
-  defp route_binding_payload(state, payload) do
-    case Jason.decode(payload) do
-      {:ok, %{"id" => query_id, "error" => err}} when is_binary(err) ->
-        resolve_find(state, query_id, {:error, :invalid_selector})
-
-      {:ok, %{"id" => query_id, "count" => count} = msg} ->
-        resolve_find(state, query_id, {:ok, count, msg["meta"]})
-
-      {:ok, %{"type" => "page_ready", "pageId" => page_id}} ->
-        update_last_page_id(state, page_id)
-
-      _ ->
-        # Other payload shapes get added here as features migrate over.
-        state
-    end
-  end
-
-  defp update_last_page_id(state, page_id) do
-    state = %{state | last_page_id: page_id}
-    wake_page_ready_waiter(state, page_id)
-  end
-
-  defp wake_page_ready_waiter(state, page_id) do
-    case state.page_ready_waiter do
-      {from, pre_page_id, timer_ref} when pre_page_id != page_id ->
-        # Either we have a real change or pre_page_id was nil and any
-        # first notification counts as ready.
-        Process.cancel_timer(timer_ref)
-        GenServer.reply(from, :ok)
-        %{state | page_ready_waiter: nil}
-
-      _ ->
-        state
-    end
-  end
-
-  defp resolve_find(state, query_id, result) do
-    case Map.get(state.find_waiters, query_id) do
-      nil ->
-        # Late or unknown query id — drop.
-        state
-
-      {:pending, timeout_ref, nil} ->
-        # Resolve into stored state; await_find_result will harvest.
-        Process.cancel_timer(timeout_ref)
-        %{state | find_waiters: Map.put(state.find_waiters, query_id, {:resolved, result})}
-
-      {:pending, timeout_ref, from} ->
-        # Caller is already blocking — reply directly and clean up.
-        Process.cancel_timer(timeout_ref)
-        GenServer.reply(from, result)
-        %{state | find_waiters: Map.delete(state.find_waiters, query_id)}
-
-      {:resolved, _} ->
-        # Idempotent — keep the first result.
-        state
-    end
   end
 
   defp wake_load_waiters(state, loader_id, name) do


### PR DESCRIPTION
## Summary

- The three Transport actors (`Session` / `PerSession.Actor` / `BiDi.SessionActor`) shared the same per-session state machine but had three copy-pasted implementations slowly drifting. This is the symptom audit item #9 flagged.
- Extracted `Wallabidi.Remote.Transport.Common` for find / page-ready / frame-stack / bootstrap-payload routing. Each actor delegates to it via plain function calls (no macro magic) so the wire- and connection-specific bits stay where they belong.
- Dropped dead `:get_page_id` and `:get_page_state` callbacks while here — no callers in `lib/` or `test/`. BiDi's `page_id` defstruct field was an unwritten orphan (drift bug).
- Net diff: +251 / -422 across 5 files. Three copies of the state machine become one.

## Why now

This is phase 1 of the "Option C" driver-as-composition direction. With the state machine centralised, future Transport changes touch one place rather than three. Subsequent phases (Protocol.Wire, Transport.Connection, Capability split, driver-as-recipe) are independent landings — none are required to ship this one.

## Test plan

- [ ] Unit tests pass locally (`mix test --exclude integration --exclude browser`): 151/151
- [ ] CI: Chrome CDP integration suite
- [ ] CI: Chrome BiDi integration suite
- [ ] CI: Lightpanda CDP integration suite
- [ ] CI: dialyzer
- [ ] CI: credo / formatter / unused-deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)