### PR TITLE
refactor(transport): extract Wire.CDP / Wire.BiDi event decoders

### DIFF
--- a/lib/wallabidi/remote/transport/bidi/session_actor.ex
+++ b/lib/wallabidi/remote/transport/bidi/session_actor.ex
@@ -14,6 +14,7 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
 
   alias Wallabidi.Remote.BiDi.WebSocketClient
   alias Wallabidi.Remote.Transport.Common
+  alias Wallabidi.Remote.Wire
 
   defstruct [
     :ws_pid,
@@ -273,41 +274,8 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
   # ----- Inbound -----
 
   @impl true
-  def handle_info({:bidi_event, "browsingContext.load", event}, state) do
-    nav = get_in(event, ["params", "navigation"])
-
-    if is_binary(nav) do
-      {:noreply, record_load(state, nav, "load")}
-    else
-      {:noreply, state}
-    end
-  end
-
-  def handle_info({:bidi_event, "browsingContext.domContentLoaded", event}, state) do
-    nav = get_in(event, ["params", "navigation"])
-
-    if is_binary(nav) do
-      {:noreply, record_load(state, nav, "DOMContentLoaded")}
-    else
-      {:noreply, state}
-    end
-  end
-
-  def handle_info({:bidi_event, "script.message", event}, state) do
-    params = Map.get(event, "params", %{})
-
-    if params["channel"] == "__wallabidi" do
-      payload = get_in(params, ["data", "value"]) || ""
-      {:noreply, Common.route_bootstrap_payload(state, payload)}
-    else
-      {:noreply, state}
-    end
-  end
-
-  def handle_info({:bidi_event, _method, _event}, state) do
-    # log.entryAdded, browsingContext.userPromptOpened, etc. — not
-    # handled at the transport level; consumers can subscribe directly.
-    {:noreply, state}
+  def handle_info({:bidi_event, method, event}, state) do
+    {:noreply, Wire.BiDi.handle_event(state, method, event)}
   end
 
   def handle_info({:find_timeout, query_id}, state) do
@@ -390,35 +358,6 @@ defmodule Wallabidi.Remote.Transport.BiDi.SessionActor do
   end
 
   defp normalize_params(other), do: other
-
-  # Decode a __wallabidi channel payload (JSON-stringified by the
-  # bootstrap) and dispatch to find_waiters or page_ready_waiter.
-  # Format mirrors the legacy SessionProcess decoder so the bootstrap
-  # JS doesn't need a BiDi-specific variant.
-  # Wake any waiter whose (navigation_id, milestone) matches — or
-  # whose loader is the `:any` wildcard (await_next_page_load).
-  # If no waiter is registered, buffer the milestone so a later
-  # caller sees it immediately.
-  defp record_load(state, nav, name) do
-    {matching, rest} =
-      Enum.split_with(state.load_waiters, fn {_from, lid, n, _ref} ->
-        (lid == nav or lid == :any) and n == name
-      end)
-
-    case matching do
-      [] ->
-        inner = Map.put(Map.get(state.loads, nav, %{}), name, true)
-        %{state | loads: Map.put(state.loads, nav, inner)}
-
-      _ ->
-        Enum.each(matching, fn {from, _, _, ref} ->
-          Process.cancel_timer(ref)
-          GenServer.reply(from, :ok)
-        end)
-
-        %{state | load_waiters: rest}
-    end
-  end
 
   # After consuming a buffered (nav, milestone), drop it so a future
   # caller for the same pair has to wait for a fresh event.

--- a/lib/wallabidi/remote/transport/common.ex
+++ b/lib/wallabidi/remote/transport/common.ex
@@ -181,6 +181,63 @@ defmodule Wallabidi.Remote.Transport.Common do
     Map.get(state.frame_contexts, frame_id)
   end
 
+  # ----- Load waiters (CDP Page.lifecycleEvent / BiDi browsingContext.load) -----
+
+  @doc """
+  Buffers a navigation milestone in `state.loads` AND wakes any matching
+  load waiter — the CDP buffer-and-wake semantics where milestones persist
+  for the lifetime of the loader_id.
+
+  Used by `Wire.CDP` for `Page.lifecycleEvent`. BiDi has different
+  semantics (`record_load_or_wake_once/3`).
+  """
+  @spec record_load_milestone(map(), term(), String.t()) :: map()
+  def record_load_milestone(state, loader_id, name) do
+    loads = Map.update(state.loads, loader_id, %{name => true}, &Map.put(&1, name, true))
+    state = %{state | loads: loads}
+
+    {ready, pending} =
+      Enum.split_with(state.load_waiters, fn
+        {_from, ^loader_id, ^name, _ref} -> true
+        {_from, :any, ^name, _ref} -> true
+        _ -> false
+      end)
+
+    Enum.each(ready, fn {from, _l, _n, ref} ->
+      Process.cancel_timer(ref)
+      GenServer.reply(from, :ok)
+    end)
+
+    %{state | load_waiters: pending}
+  end
+
+  @doc """
+  BiDi load-event semantics: if a matching waiter exists, wake it; otherwise
+  buffer the milestone for a later `await_page_load` (which then consumes
+  and drops it). Distinct from `record_load_milestone/3` — see comment there.
+  """
+  @spec record_load_or_wake_once(map(), term(), String.t()) :: map()
+  def record_load_or_wake_once(state, loader_id, name) do
+    {matching, rest} =
+      Enum.split_with(state.load_waiters, fn {_from, lid, n, _ref} ->
+        (lid == loader_id or lid == :any) and n == name
+      end)
+
+    case matching do
+      [] ->
+        inner = Map.put(Map.get(state.loads, loader_id, %{}), name, true)
+        %{state | loads: Map.put(state.loads, loader_id, inner)}
+
+      _ ->
+        Enum.each(matching, fn {from, _, _, ref} ->
+          Process.cancel_timer(ref)
+          GenServer.reply(from, :ok)
+        end)
+
+        %{state | load_waiters: rest}
+    end
+  end
+
   # ----- Bootstrap channel payload routing -----
 
   @doc """

--- a/lib/wallabidi/remote/transport/per_session/actor.ex
+++ b/lib/wallabidi/remote/transport/per_session/actor.ex
@@ -22,6 +22,7 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
   require Logger
 
   alias Wallabidi.Remote.Transport.Common
+  alias Wallabidi.Remote.Wire
 
   defstruct [
     # ----- Connection state (was WebSocket) -----
@@ -370,7 +371,7 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
         deliver_response(state, id, response)
 
       {:ok, %{"method" => method} = event} ->
-        handle_event(state, method, event)
+        Wire.CDP.handle_event(state, method, event)
 
       {:error, _} ->
         Logger.warning("PerSession.Actor invalid JSON: #{inspect(String.slice(text, 0, 200))}")
@@ -399,84 +400,6 @@ defmodule Wallabidi.Remote.Transport.PerSession.Actor do
         GenServer.reply(from, parse_response(response))
         %{state | pending_calls: pending}
     end
-  end
-
-  # ----- Event handling -----
-
-  defp handle_event(state, "Page.lifecycleEvent", event) do
-    params = Map.get(event, "params", %{})
-    loader_id = params["loaderId"]
-    name = params["name"]
-
-    if is_binary(loader_id) and name in ["load", "DOMContentLoaded"] do
-      state = buffer_load(state, loader_id, name)
-      wake_load_waiters(state, loader_id, name)
-    else
-      state
-    end
-  end
-
-  defp handle_event(state, "Runtime.bindingCalled", event) do
-    params = Map.get(event, "params", %{})
-
-    if params["name"] == "__wallabidi" and is_binary(params["payload"]) do
-      Common.route_bootstrap_payload(state, params["payload"])
-    else
-      state
-    end
-  end
-
-  defp handle_event(state, "Runtime.executionContextCreated", event) do
-    ctx = get_in(event, ["params", "context"]) || %{}
-    aux = Map.get(ctx, "auxData", %{})
-    context_id = ctx["id"]
-    frame_id = aux["frameId"]
-
-    if is_integer(context_id) and is_binary(frame_id) do
-      %{state | frame_contexts: Map.put(state.frame_contexts, frame_id, context_id)}
-    else
-      state
-    end
-  end
-
-  defp handle_event(state, "Runtime.executionContextDestroyed", event) do
-    destroyed = get_in(event, ["params", "executionContextId"])
-
-    if is_integer(destroyed) do
-      contexts =
-        state.frame_contexts
-        |> Enum.reject(fn {_frame_id, ctx_id} -> ctx_id == destroyed end)
-        |> Map.new()
-
-      %{state | frame_contexts: contexts}
-    else
-      state
-    end
-  end
-
-  defp handle_event(state, _method, _event), do: state
-
-  # ----- Helpers (was Session helpers) -----
-
-  defp buffer_load(state, loader_id, name) do
-    loads = Map.update(state.loads, loader_id, %{name => true}, &Map.put(&1, name, true))
-    %{state | loads: loads}
-  end
-
-  defp wake_load_waiters(state, loader_id, name) do
-    {ready, pending} =
-      Enum.split_with(state.load_waiters, fn
-        {_from, ^loader_id, ^name, _ref} -> true
-        {_from, :any, ^name, _ref} -> true
-        _ -> false
-      end)
-
-    Enum.each(ready, fn {from, _l, _n, ref} ->
-      Process.cancel_timer(ref)
-      GenServer.reply(from, :ok)
-    end)
-
-    %{state | load_waiters: pending}
   end
 
   # ----- Wire frame send -----

--- a/lib/wallabidi/remote/transport/session.ex
+++ b/lib/wallabidi/remote/transport/session.ex
@@ -19,6 +19,7 @@ defmodule Wallabidi.Remote.Transport.Session do
 
   alias Wallabidi.Remote.Transport.Common
   alias Wallabidi.Remote.WebSocket
+  alias Wallabidi.Remote.Wire
 
   defstruct [
     :session,
@@ -526,72 +527,8 @@ defmodule Wallabidi.Remote.Transport.Session do
     end
   end
 
-  def handle_info({:v2_event, "Page.lifecycleEvent", event}, state) do
-    params = Map.get(event, "params", %{})
-    loader_id = params["loaderId"]
-    name = params["name"]
-
-    if is_binary(loader_id) and name in ["load", "DOMContentLoaded"] do
-      state = buffer_load(state, loader_id, name)
-      state = wake_load_waiters(state, loader_id, name)
-      {:noreply, state}
-    else
-      {:noreply, state}
-    end
-  end
-
-  def handle_info({:v2_event, "Runtime.bindingCalled", event}, state) do
-    params = Map.get(event, "params", %{})
-
-    if params["name"] == "__wallabidi" and is_binary(params["payload"]) do
-      {:noreply, Common.route_bootstrap_payload(state, params["payload"])}
-    else
-      {:noreply, state}
-    end
-  end
-
-  def handle_info({:v2_event, "Runtime.executionContextCreated", event}, state) do
-    # Chrome assigns a fresh executionContextId for each frame's main
-    # JS realm. Record `auxData.frameId → contextId` so focus_frame
-    # can resolve a frame element to its execution context.
-    ctx = get_in(event, ["params", "context"]) || %{}
-    aux = Map.get(ctx, "auxData", %{})
-    context_id = ctx["id"]
-    frame_id = aux["frameId"]
-
-    state =
-      if is_integer(context_id) and is_binary(frame_id) do
-        %{state | frame_contexts: Map.put(state.frame_contexts, frame_id, context_id)}
-      else
-        state
-      end
-
-    {:noreply, state}
-  end
-
-  def handle_info({:v2_event, "Runtime.executionContextDestroyed", event}, state) do
-    # Drop the destroyed contextId from frame_contexts. This prevents
-    # focus_frame from handing out stale contexts after a navigation.
-    destroyed = get_in(event, ["params", "executionContextId"])
-
-    state =
-      if is_integer(destroyed) do
-        contexts =
-          state.frame_contexts
-          |> Enum.reject(fn {_frame_id, ctx_id} -> ctx_id == destroyed end)
-          |> Map.new()
-
-        %{state | frame_contexts: contexts}
-      else
-        state
-      end
-
-    {:noreply, state}
-  end
-
-  def handle_info({:v2_event, _method, _event}, state) do
-    # Routes for other event types land here as we migrate them.
-    {:noreply, state}
+  def handle_info({:v2_event, method, event}, state) do
+    {:noreply, Wire.CDP.handle_event(state, method, event)}
   end
 
   def handle_info({:load_timeout, from}, state) do
@@ -639,32 +576,4 @@ defmodule Wallabidi.Remote.Transport.Session do
   end
 
   def terminate(_reason, _state), do: :ok
-
-  # ----- Helpers -----
-
-  defp buffer_load(state, loader_id, name) do
-    loads =
-      Map.update(state.loads, loader_id, %{name => true}, &Map.put(&1, name, true))
-
-    %{state | loads: loads}
-  end
-
-  defp wake_load_waiters(state, loader_id, name) do
-    {ready, pending} =
-      Enum.split_with(state.load_waiters, fn
-        # Specific loader_id match.
-        {_from, ^loader_id, ^name, _ref} -> true
-        # Wildcard waiter from await_next_page_load — woken by any
-        # matching milestone regardless of loader_id.
-        {_from, :any, ^name, _ref} -> true
-        _ -> false
-      end)
-
-    Enum.each(ready, fn {from, _l, _n, ref} ->
-      Process.cancel_timer(ref)
-      GenServer.reply(from, :ok)
-    end)
-
-    %{state | load_waiters: pending}
-  end
 end

--- a/lib/wallabidi/remote/wire/bidi.ex
+++ b/lib/wallabidi/remote/wire/bidi.ex
@@ -1,0 +1,59 @@
+defmodule Wallabidi.Remote.Wire.BiDi do
+  @moduledoc false
+
+  # BiDi wire-level event decoder used by
+  # `Wallabidi.Remote.Transport.BiDi.SessionActor`. BiDi events arrive
+  # pre-decoded as `{:bidi_event, method, event}` messages from the
+  # `BiDi.WebSocketClient`.
+  #
+  # `handle_event/3` is a pure function over the actor's state map.
+
+  alias Wallabidi.Remote.Transport.Common
+
+  @doc """
+  Decodes one BiDi event for an actor's state. Returns the new state.
+
+  Recognised events:
+
+    * `browsingContext.load` / `browsingContext.domContentLoaded` —
+      navigation milestones; either wake a matching load waiter or
+      buffer the milestone (BiDi one-shot semantics).
+    * `script.message` — bootstrap channel; routed to
+      `Common.route_bootstrap_payload/2` when the channel name matches.
+
+  Unknown methods are a no-op.
+  """
+  @spec handle_event(map(), String.t(), map()) :: map()
+  def handle_event(state, method, event)
+
+  def handle_event(state, "browsingContext.load", event) do
+    record_milestone(state, event, "load")
+  end
+
+  def handle_event(state, "browsingContext.domContentLoaded", event) do
+    record_milestone(state, event, "DOMContentLoaded")
+  end
+
+  def handle_event(state, "script.message", event) do
+    params = Map.get(event, "params", %{})
+
+    if params["channel"] == "__wallabidi" do
+      payload = get_in(params, ["data", "value"]) || ""
+      Common.route_bootstrap_payload(state, payload)
+    else
+      state
+    end
+  end
+
+  def handle_event(state, _method, _event), do: state
+
+  defp record_milestone(state, event, milestone) do
+    nav = get_in(event, ["params", "navigation"])
+
+    if is_binary(nav) do
+      Common.record_load_or_wake_once(state, nav, milestone)
+    else
+      state
+    end
+  end
+end

--- a/lib/wallabidi/remote/wire/cdp.ex
+++ b/lib/wallabidi/remote/wire/cdp.ex
@@ -1,0 +1,89 @@
+defmodule Wallabidi.Remote.Wire.CDP do
+  @moduledoc false
+
+  # CDP wire-level event decoder shared by the two CDP transport actors:
+  #
+  #   * `Wallabidi.Remote.Transport.Session` (Chrome CDP, shared WS)
+  #   * `Wallabidi.Remote.Transport.PerSession.Actor` (Lightpanda, per-session WS)
+  #
+  # Both subscribe to the same handful of CDP events and translate them
+  # into state-machine updates handled by `Wallabidi.Remote.Transport.Common`.
+  # Decoding the events lives here so the two actors stop carrying
+  # byte-identical clauses.
+  #
+  # `handle_event/3` is a pure function over the actor's state map; the
+  # actor wraps the return value in `{:noreply, state}` (Session) or
+  # threads it through its WS-frame loop (PerSession.Actor).
+
+  alias Wallabidi.Remote.Transport.Common
+
+  @doc """
+  Decodes one CDP event for an actor's state. Returns the new state.
+
+  Recognised events:
+
+    * `Page.lifecycleEvent` — record `(loaderId, milestone)` so any
+      matching load waiter wakes immediately (or the milestone buffers
+      for a later caller).
+    * `Runtime.bindingCalled` — bootstrap channel; routed to
+      `Common.route_bootstrap_payload/2` when the binding name matches.
+    * `Runtime.executionContextCreated` — record `frameId → contextId`.
+    * `Runtime.executionContextDestroyed` — purge the destroyed context.
+
+  Unknown methods are a no-op.
+  """
+  @spec handle_event(map(), String.t(), map()) :: map()
+  def handle_event(state, method, event)
+
+  def handle_event(state, "Page.lifecycleEvent", event) do
+    params = Map.get(event, "params", %{})
+    loader_id = params["loaderId"]
+    name = params["name"]
+
+    if is_binary(loader_id) and name in ["load", "DOMContentLoaded"] do
+      Common.record_load_milestone(state, loader_id, name)
+    else
+      state
+    end
+  end
+
+  def handle_event(state, "Runtime.bindingCalled", event) do
+    params = Map.get(event, "params", %{})
+
+    if params["name"] == "__wallabidi" and is_binary(params["payload"]) do
+      Common.route_bootstrap_payload(state, params["payload"])
+    else
+      state
+    end
+  end
+
+  def handle_event(state, "Runtime.executionContextCreated", event) do
+    ctx = get_in(event, ["params", "context"]) || %{}
+    aux = Map.get(ctx, "auxData", %{})
+    context_id = ctx["id"]
+    frame_id = aux["frameId"]
+
+    if is_integer(context_id) and is_binary(frame_id) do
+      %{state | frame_contexts: Map.put(state.frame_contexts, frame_id, context_id)}
+    else
+      state
+    end
+  end
+
+  def handle_event(state, "Runtime.executionContextDestroyed", event) do
+    destroyed = get_in(event, ["params", "executionContextId"])
+
+    if is_integer(destroyed) do
+      contexts =
+        state.frame_contexts
+        |> Enum.reject(fn {_frame_id, ctx_id} -> ctx_id == destroyed end)
+        |> Map.new()
+
+      %{state | frame_contexts: contexts}
+    else
+      state
+    end
+  end
+
+  def handle_event(state, _method, _event), do: state
+end


### PR DESCRIPTION
## Summary

Phase 2 of the Option C driver-as-composition direction (phase 1 is #28 — Transport.Common). **This PR is stacked on #28** — base set to `refactor/transport-common` so the diff is just phase-2's delta.

- The two CDP transport actors (`Session`, `PerSession.Actor`) were decoding the same four CDP events with byte-identical clauses. Extracted into `Wallabidi.Remote.Wire.CDP` as a pure `handle_event(state, method, event) :: state` function.
- Added symmetric `Wallabidi.Remote.Wire.BiDi` for the three BiDi events the actor cares about (`browsingContext.load` / `.domContentLoaded` / `script.message`).
- Hoisted the buffer-and-wake load-waiter logic into `Transport.Common`. Two distinct entry points:
  - `Common.record_load_milestone/3` — CDP semantics (buffer permanently + wake).
  - `Common.record_load_or_wake_once/3` — BiDi semantics (buffer-or-wake, one-shot).
- Pre-existing behavioural divergence between the two preserved as-is. Unifying that is a follow-up — it changes behaviour, not just shape.

## Why now

With Wire.CDP and Wire.BiDi in place, the actors are clearly composing `{shared state machine, wire decoder, transport}`. The Option C end goal (Phase 5: drivers as recipes) is one step closer.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test --exclude integration --exclude browser` — 151/151 pass locally
- [ ] CI: Chrome CDP integration
- [ ] CI: Chrome BiDi integration
- [ ] CI: Lightpanda CDP integration
- [ ] CI: LiveView Driver
- [ ] CI: dialyzer / linting / unit-test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)