### PR TITLE
fix(ci): lint, driver-tag, dialyzer, and Chrome startup-timeout fixes

### DIFF
--- a/integration_test/cases/browser/event_capture_test.exs
+++ b/integration_test/cases/browser/event_capture_test.exs
@@ -25,14 +25,19 @@ defmodule Wallabidi.Integration.Browser.EventCaptureTest do
   # Lightpanda CDP, while bubble-phase listeners on document do.
 
   use Wallabidi.Integration.SessionCase, async: false
+  # Needs a JS-capable browser (execute_script + real DOM event flow).
+  # :headless runs it on Lightpanda + both Chrome drivers and excludes the
+  # in-process LiveView driver, which has no execute_script.
+  @moduletag :headless
 
   @base Application.compile_env(:wallabidi, :live_app_url, "http://localhost:4321")
 
   @phases ["root-capture", "root-bubble", "document-capture", "document-bubble"]
 
   describe "DOM event propagation parity (vanilla page)" do
-    # No capability tag — DOM event flow is the spec; every JS-capable
-    # driver should pass this. Filing the failures here is the point.
+    # DOM event flow is the spec; every JS-capable driver should pass this
+    # (module is tagged :headless, so it runs on Lightpanda + both Chrome
+    # drivers — not the in-process LiveView driver).
     test "Wallabidi.Browser.click fires all four phases", %{session: session} do
       session = visit(session, @base <> "/event-capture")
       assert_all_zero(session)

--- a/lib/wallabidi/browser.ex
+++ b/lib/wallabidi/browser.ex
@@ -871,29 +871,29 @@ defmodule Wallabidi.Browser do
   defp click_deferred(parent, query) do
     session = get_session(parent)
 
-    cond do
-      is_nil(session) or is_nil(session.driver_spec) ->
-        # No spec (LV driver, or unusual session shape) → fall through
-        # to the normal click. There's no awaiting machinery to skip.
-        click_auto(parent, query)
+    # No spec (LV driver, or unusual session shape) → fall through to the
+    # normal click; there's no awaiting machinery to skip.
+    if is_nil(session) or is_nil(session.driver_spec) do
+      click_auto(parent, query)
+    else
+      orchestrator = Wallabidi.Remote.Driver.Orchestrator
 
-      true ->
-        case find_lazy(parent, query) do
-          %Element{} = element ->
-            case Wallabidi.Remote.Driver.Orchestrator.click_deferred(session.driver_spec, element) do
-              {:ok, pre_page_id} ->
-                %{session | pending_await: {:page_ready_after, pre_page_id}}
+      case find_lazy(parent, query) do
+        %Element{} = element ->
+          case orchestrator.click_deferred(session.driver_spec, element) do
+            {:ok, pre_page_id} ->
+              %{session | pending_await: {:page_ready_after, pre_page_id}}
 
-              {:error, _} ->
-                # Click dispatch failed (e.g. transport issue). Don't
-                # stash a half-baked await — fall back to whatever
-                # surface error handling the assertion does.
-                session
-            end
+            {:error, _} ->
+              # Click dispatch failed (e.g. transport issue). Don't stash a
+              # half-baked await — fall back to whatever surface error
+              # handling the assertion does.
+              session
+          end
 
-          other ->
-            other
-        end
+        other ->
+          other
+      end
     end
   end
 

--- a/lib/wallabidi/installer.ex
+++ b/lib/wallabidi/installer.ex
@@ -324,13 +324,11 @@ defmodule Wallabidi.Installer do
   # cwd-relative for in-tree development (where Mix.Project is wallabidi
   # itself).
   defp bidi_server_dir do
-    case Application.app_dir(:wallabidi, "priv/bidi-server") do
-      path when is_binary(path) ->
-        if File.dir?(path), do: path, else: cwd_bidi_server_dir()
-
-      _ ->
-        cwd_bidi_server_dir()
-    end
+    # Application.app_dir/2 returns a path string (and raises ArgumentError
+    # if :wallabidi isn't loaded — caught below). Use it when it points at a
+    # real dir, otherwise fall back to cwd-relative for in-tree dev.
+    path = Application.app_dir(:wallabidi, "priv/bidi-server")
+    if File.dir?(path), do: path, else: cwd_bidi_server_dir()
   rescue
     ArgumentError -> cwd_bidi_server_dir()
   end

--- a/lib/wallabidi/live_view.ex
+++ b/lib/wallabidi/live_view.ex
@@ -74,7 +74,11 @@ defmodule Wallabidi.LiveView do
   def set_latency(%Session{} = session, latency_ms)
       when is_integer(latency_ms) and latency_ms >= 0 do
     if remote?(session) do
-      _ = eval_silent(session, "window.liveSocket && window.liveSocket.enableLatencySim(#{latency_ms})")
+      _ =
+        eval_silent(
+          session,
+          "window.liveSocket && window.liveSocket.enableLatencySim(#{latency_ms})"
+        )
     end
 
     session

--- a/lib/wallabidi/remote/chrome/server.ex
+++ b/lib/wallabidi/remote/chrome/server.ex
@@ -18,7 +18,11 @@ defmodule Wallabidi.Remote.Chrome.Server do
     calls_awaiting_readiness: []
   ]
 
-  @startup_timeout 15_000
+  # Time to wait for Chrome to emit its DevTools WebSocket URL. 30s (was
+  # 15s) — a cold Chrome on a contended CI runner can take >15s to start,
+  # which surfaced as intermittent :startup_timeout failures. Matches the
+  # chromium-bidi server's startup budget.
+  @startup_timeout 30_000
 
   def child_spec(opts) do
     %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}}

--- a/test/wallabidi/browser_paths_test.exs
+++ b/test/wallabidi/browser_paths_test.exs
@@ -51,14 +51,27 @@ defmodule Wallabidi.BrowserPathsTest do
       # The lightpanda dep exposes target/0 + release/0, so this resolves.
       assert is_binary(dir)
       assert String.starts_with?(dir, Path.join(".browsers", "lightpanda"))
-      assert dir == Path.join([".browsers", "lightpanda", "#{Lightpanda.target()}-#{Lightpanda.release()}"])
+
+      assert dir ==
+               Path.join([
+                 ".browsers",
+                 "lightpanda",
+                 "#{Lightpanda.target()}-#{Lightpanda.release()}"
+               ])
     end
   end
 
   describe "chrome_for_testing_unsupported?/2" do
     test "true only on arm/aarch64 Linux" do
-      assert BrowserPaths.chrome_for_testing_unsupported?({:unix, :linux}, "aarch64-unknown-linux-gnu")
-      assert BrowserPaths.chrome_for_testing_unsupported?({:unix, :linux}, "armv7l-unknown-linux-gnueabihf")
+      assert BrowserPaths.chrome_for_testing_unsupported?(
+               {:unix, :linux},
+               "aarch64-unknown-linux-gnu"
+             )
+
+      assert BrowserPaths.chrome_for_testing_unsupported?(
+               {:unix, :linux},
+               "armv7l-unknown-linux-gnueabihf"
+             )
     end
 
     test "false on x86_64 Linux (Chrome for Testing ships a build)" do
@@ -66,7 +79,10 @@ defmodule Wallabidi.BrowserPathsTest do
     end
 
     test "false on macOS regardless of arch (system Chrome / CfT both fine)" do
-      refute BrowserPaths.chrome_for_testing_unsupported?({:unix, :darwin}, "aarch64-apple-darwin")
+      refute BrowserPaths.chrome_for_testing_unsupported?(
+               {:unix, :darwin},
+               "aarch64-apple-darwin"
+             )
     end
 
     test "false on Windows" do


### PR DESCRIPTION
Clean, self-contained CI fixes (the lint/driver-tag/dialyzer/startup subset, split out from the larger SharedConnection work so it can land independently).

- **format**: over-long lines in `browser_paths_test.exs` and `live_view.ex`.
- **credo --strict**: `Browser.click_deferred/2` used a `cond` with a single real condition → rewritten as `if/else`.
- **dialyzer**: removed an unreachable `_ ->` clause in `installer.ex`'s `bidi_server_dir/0` (`Application.app_dir/2` always returns a binary).
- **LiveView Driver job**: `event_capture_test.exs` was untagged, so it ran on the in-process LV driver and failed with `execute_script not supported` → tagged `:headless` (runs on Lightpanda + Chrome).
- **Chrome `@startup_timeout` 15s→30s**: a cold Chrome on a loaded CI runner can take >15s to emit its DevTools URL (measured ~25s), which surfaced as `:startup_timeout`.

Verified locally: `mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors`, full unit suite (178 tests, 0 failures).

Follow-ups (separate PRs): persistent_term pid-acquisition serialization, then the event-driven-regression detector that replaces the wall-clock SlowTestGuard.