### PR TITLE
refactor(transport): lock-free SharedConnection reads via persistent_term

### DIFF
--- a/lib/wallabidi/remote/chrome/shared_connection.ex
+++ b/lib/wallabidi/remote/chrome/shared_connection.ex
@@ -8,11 +8,31 @@ defmodule Wallabidi.Remote.Chrome.SharedConnection do
   # Lazy-connect on first `get/1` call — by then the driver supervisor
   # has already started either a local Chrome (`Chrome.Server`) or we
   # have a remote URL to connect to.
+  #
+  # The connected pid is an immutable, process-wide value, so the read
+  # path needs no serialization: `get/1` reads it lock-free from
+  # `:persistent_term` and returns it directly. Only the rare *write* (the
+  # one-time cold connect, or a reconnect after the WS dies) is serialized,
+  # through a thin Agent — so exactly one connection is ever created
+  # (concurrent first-acquirers all resolve to the same pid via a
+  # double-check), and the one-time startup wait isn't multiplied. Every
+  # subsequent `get/1` (≈ once per test) is a lock-free term read, not a
+  # message round-trip.
 
   use Agent
 
   alias Wallabidi.Remote.WebSocket
 
+  @pid_key {__MODULE__, :ws_pid}
+
+  # Must exceed Chrome.Server's @startup_timeout (30s): on a cold start the
+  # serialized connect blocks until Chrome emits its DevTools URL, and
+  # callers queued behind it wait for that same connect.
+  @connect_timeout 40_000
+
+  # The Agent holds no state — the pid lives in :persistent_term. The Agent
+  # exists purely to serialize the connect (its mailbox is the one-at-a-time
+  # gate). State is `nil`.
   def start_link(_opts) do
     Agent.start_link(fn -> nil end, name: __MODULE__)
   end
@@ -24,13 +44,38 @@ defmodule Wallabidi.Remote.Chrome.SharedConnection do
   """
   @spec get(module) :: pid
   def get(driver_mod) do
-    Agent.get_and_update(__MODULE__, fn
+    case :persistent_term.get(@pid_key, nil) do
       pid when is_pid(pid) ->
-        if Process.alive?(pid), do: {pid, pid}, else: connect(driver_mod)
+        if Process.alive?(pid), do: pid, else: connect_serialized(driver_mod)
 
       nil ->
-        connect(driver_mod)
-    end)
+        connect_serialized(driver_mod)
+    end
+  end
+
+  # Serialize the connect through the Agent. The update fn double-checks
+  # persistent_term: a caller queued behind a concurrent connect will see
+  # the now-live pid and return it rather than connecting again.
+  defp connect_serialized(driver_mod) do
+    Agent.get_and_update(
+      __MODULE__,
+      fn nil ->
+        pid =
+          case :persistent_term.get(@pid_key, nil) do
+            p when is_pid(p) -> if Process.alive?(p), do: p, else: do_connect(driver_mod)
+            nil -> do_connect(driver_mod)
+          end
+
+        {pid, nil}
+      end,
+      @connect_timeout
+    )
+  end
+
+  defp do_connect(driver_mod) do
+    pid = connect(driver_mod)
+    :persistent_term.put(@pid_key, pid)
+    pid
   end
 
   defp connect(driver_mod) do
@@ -55,11 +100,11 @@ defmodule Wallabidi.Remote.Chrome.SharedConnection do
       end
 
     # WebSocket.start_link would link to the *current caller* (the test
-    # process invoking Agent.get_and_update), so the shared WS would die
-    # when each test exits. Use `start/1` for an unlinked process whose
-    # lifetime is tied to the SharedConnection Agent instead.
+    # process invoking get/1), so the shared WS would die when each test
+    # exits. Use `start/1` for an unlinked process whose lifetime is tied
+    # to the SharedConnection Agent instead.
     {:ok, pid} = WebSocket.start(ws_url)
-    {pid, pid}
+    pid
   end
 
   # Same /json/version discovery logic as ChromeCDP.SharedConnection.

--- a/test/wallabidi/shared_connection_test.exs
+++ b/test/wallabidi/shared_connection_test.exs
@@ -1,0 +1,72 @@
+defmodule Wallabidi.Remote.Chrome.SharedConnectionTest do
+  # Not async: starts the named SharedConnection Agent and mutates the
+  # shared :persistent_term holding the ws pid.
+  use ExUnit.Case, async: false
+
+  alias Wallabidi.Remote.Chrome.SharedConnection
+
+  @pid_key {SharedConnection, :ws_pid}
+
+  setup do
+    prev = :persistent_term.get(@pid_key, :unset)
+
+    # A long-lived dummy process to stand in for the WebSocket pid — get/1
+    # only checks Process.alive?, it doesn't talk to it on the read path.
+    {:ok, fake_ws} = Agent.start_link(fn -> :ok end)
+
+    {:ok, agent} =
+      case Process.whereis(SharedConnection) do
+        nil -> SharedConnection.start_link([])
+        pid -> {:ok, pid}
+      end
+
+    on_exit(fn ->
+      if Process.alive?(fake_ws), do: Agent.stop(fake_ws)
+
+      case prev do
+        :unset -> :persistent_term.erase(@pid_key)
+        v -> :persistent_term.put(@pid_key, v)
+      end
+
+      if is_pid(agent) and Process.alive?(agent), do: Agent.stop(agent)
+    end)
+
+    %{fake_ws: fake_ws}
+  end
+
+  test "get/1 returns the live pid from persistent_term without reconnecting",
+       %{fake_ws: fake_ws} do
+    :persistent_term.put(@pid_key, fake_ws)
+    # No Chrome/driver needed — the live-pid branch short-circuits before
+    # any connect. A reconnect attempt would crash (no driver server), so a
+    # clean return proves the read path didn't reconnect.
+    assert SharedConnection.get(:no_driver) == fake_ws
+  end
+
+  test "concurrent get/1 with a live pid all return the same pid, lock-free",
+       %{fake_ws: fake_ws} do
+    :persistent_term.put(@pid_key, fake_ws)
+
+    results =
+      1..50
+      |> Task.async_stream(fn _ -> SharedConnection.get(:no_driver) end,
+        max_concurrency: 50,
+        ordered: false
+      )
+      |> Enum.map(fn {:ok, pid} -> pid end)
+
+    assert Enum.all?(results, &(&1 == fake_ws))
+  end
+
+  test "a dead stored pid triggers the (serialized) reconnect path", %{fake_ws: fake_ws} do
+    # Store a dead pid; get/1 should NOT return it — it should fall to the
+    # connect path. We don't have a real driver, so the connect raises; the
+    # point is that the dead pid is rejected (not returned as-is).
+    Agent.stop(fake_ws)
+    refute Process.alive?(fake_ws)
+    :persistent_term.put(@pid_key, fake_ws)
+
+    assert catch_exit(SharedConnection.get(:no_driver)) != nil or
+             catch_error(SharedConnection.get(:no_driver)) != nil
+  end
+end


### PR DESCRIPTION
Re-targets the persistent_term work to `main`. (The original #35 was stacked on #34's branch and, after #34 merged via squash, its commits never reached `main` — this PR brings them in cleanly against current `main`.)

The shared Chrome WebSocket pid is an immutable, process-wide value, so reads need no serialization. Store it in `:persistent_term` and read lock-free: `get/1` (≈ once per test) becomes a direct term read + `Process.alive?`, not a message round-trip. Only the rare **write** (one-time cold connect, or reconnect after the WS dies) is serialized through a thin Agent whose update fn double-checks `persistent_term`, so concurrent first-acquirers all resolve to the same pid (exactly one connection, no race).

Adds `SharedConnectionTest`: live-pid read returns without reconnecting; 50 concurrent reads all return the same pid lock-free; a dead stored pid triggers the serialized reconnect path.

Verified: unit suite (181 tests), sandbox suite at `--max-cases 8` clean across repeated runs.