### PR TITLE
ci: add Elixir 1.18 (OTP 27), bump 1.20 to rc.6; correct setup docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         elixir-otp:
+          - {otp: 27.x, elixir: 1.18.x}
           - {otp: 28.x, elixir: 1.19.x}
-          - {otp: 28.4.1, elixir: 1.20.0-rc.4, version_type: strict, experimental: true}
+          - {otp: 28.4.1, elixir: 1.20.0-rc.6, version_type: strict, experimental: true}
       fail-fast: false
 
     steps:

--- a/guides/setup.md
+++ b/guides/setup.md
@@ -1,6 +1,6 @@
 # Setup
 
-Requires Elixir 1.19+, OTP 28+. Use `mix wallabidi.install` to download the browsers the drivers need (Chrome for Testing, Lightpanda, and the chromium-bidi Node deps) into `.browsers/`, or point the `WALLABIDI_*_PATH` env vars at existing binaries.
+Requires Elixir 1.18+ (1.18 on OTP 25–27; 1.19+ on OTP 28). Use `mix wallabidi.install` to download the browsers the drivers need (Chrome for Testing, Lightpanda, and the chromium-bidi Node deps) into `.browsers/`, or point the `WALLABIDI_*_PATH` env vars at existing binaries.
 
 ## Installation
 


### PR DESCRIPTION
## What

Widen the unit-test CI matrix and correct the version requirement in the setup guide.

### CI matrix (`.github/workflows/ci.yml`)
- **Add `{otp: 27.x, elixir: 1.18.x}`** — `mix.exs` already declares `~> 1.18`, so 1.18 was nominally supported but never actually exercised. OTP 27 is the newest OTP that Elixir 1.18 supports (1.18 does not support OTP 28).
- **Keep `1.19.x` / OTP 28** as the primary supported row.
- **Bump the experimental `1.20.0-rc.4` row to `rc.6`** (latest 1.20 release candidate). Still `experimental: true`, so non-blocking.

### Docs (`guides/setup.md`)
- The requirement line said *"Requires Elixir 1.19+, OTP 28+"*, which contradicts the `~> 1.18` constraint. Corrected to *"Requires Elixir 1.18+ (1.18 on OTP 25–27; 1.19+ on OTP 28)"*.

## Notes
- CHANGELOG version references are historical entries and were left as-is.
- The illustrative CI snippets in `setup.md` (showing `1.19.x`) are fine — 1.19 remains the primary supported row.
- `release.yaml` still pins `1.17.x` for the release job — separate concern, not touched here.
- If the new 1.18 row goes red, it's a genuine 1.18 incompatibility worth surfacing (the lib has been developed against 1.19/OTP 28). A grep for post-1.18 stdlib usage (`JSON.`, `:eager`, `Duration`) came back clean — all hits were JS strings or internal atoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)