### PR TITLE
chore(test): remove dead @tag :polling annotations

### DIFF
--- a/integration_test/cases/browser/assert_css_test.exs
+++ b/integration_test/cases/browser/assert_css_test.exs
@@ -9,8 +9,6 @@ defmodule Wallabidi.Integration.Browser.AssertCssTest do
     assert has_css?(page, ".user")
   end
 
-  @tag :polling
-
   test "has_css/2 returns false if the css is not on the page", %{session: session} do
     page =
       session
@@ -26,8 +24,6 @@ defmodule Wallabidi.Integration.Browser.AssertCssTest do
 
     assert has_css?(page, Query.css(".dashboard"), ".users")
   end
-
-  @tag :polling
 
   test "has_css/3 returns false if the css is not on the page", %{session: session} do
     page =
@@ -45,8 +41,6 @@ defmodule Wallabidi.Integration.Browser.AssertCssTest do
     assert has_no_css?(page, ".something_else")
   end
 
-  @tag :polling
-
   test "has_no_css/2 returns false if the css is on the page", %{session: session} do
     page =
       session
@@ -54,8 +48,6 @@ defmodule Wallabidi.Integration.Browser.AssertCssTest do
 
     refute has_no_css?(page, ".user")
   end
-
-  @tag :polling
 
   test "has_no_css/3 returns false if the css is on the page", %{session: session} do
     page =

--- a/integration_test/cases/browser/assert_refute_has_test.exs
+++ b/integration_test/cases/browser/assert_refute_has_test.exs
@@ -18,8 +18,6 @@ defmodule Wallabidi.Integration.Browser.AssertRefuteHasTest do
       assert %Wallabidi.Session{} = return
     end
 
-    @tag :polling
-
     test "raises if the query is not found", %{session: session} do
       assert_raise ExpectationNotMetError, ~r/Expected.+ 1.*css.*\.something-else.*0/i, fn ->
         session
@@ -28,7 +26,6 @@ defmodule Wallabidi.Integration.Browser.AssertRefuteHasTest do
       end
     end
 
-    @tag :polling
     test "mentions the count of found vs. expected elements", %{session: session} do
       assert_raise ExpectationNotMetError, ~r/Expected.+ 5.*css.*\.user.*6/i, fn ->
         session
@@ -59,7 +56,6 @@ defmodule Wallabidi.Integration.Browser.AssertRefuteHasTest do
   end
 
   describe "refute_has/2" do
-    @tag :polling
     test "passes if the query is not found on the page", %{session: session} do
       return =
         session

--- a/integration_test/cases/browser/assert_text_test.exs
+++ b/integration_test/cases/browser/assert_text_test.exs
@@ -4,7 +4,6 @@ defmodule Wallabidi.Integration.Browser.AssertTextTest do
 
   alias Wallabidi.ExpectationNotMetError
 
-  @tag :polling
   test "has_text?/2 waits for presence of text and returns a bool", %{session: session} do
     element =
       session
@@ -25,8 +24,6 @@ defmodule Wallabidi.Integration.Browser.AssertTextTest do
 
     assert element == assert_text(element, "main")
   end
-
-  @tag :polling
 
   test "assert_text/2 will raise an exception for text not found", %{session: session} do
     element =

--- a/integration_test/cases/browser/clear_test.exs
+++ b/integration_test/cases/browser/clear_test.exs
@@ -1,7 +1,6 @@
 defmodule Wallabidi.Integration.Browser.ClearTest do
   use Wallabidi.Integration.SessionCase, async: true
 
-  @tag :polling
   test "clearing input", %{session: session} do
     element =
       session

--- a/integration_test/cases/browser/click_button_test.exs
+++ b/integration_test/cases/browser/click_button_test.exs
@@ -266,15 +266,11 @@ defmodule Wallabidi.Integration.Browser.Actions.ClickButtonTest do
     assert click(page, button("Hidden Button"))
   end
 
-  @tag :polling
-
   test "throws an error if the button does not include a valid type attribute", %{page: page} do
     assert_raise Wallabidi.QueryError, ~r/button has an invalid 'type'/, fn ->
       click(page, button("button with bad type", []))
     end
   end
-
-  @tag :polling
 
   test "throws an error if clicking on an input with no type", %{page: page} do
     assert_raise Wallabidi.QueryError, ~r/Expected (.*) 1/, fn ->
@@ -282,7 +278,6 @@ defmodule Wallabidi.Integration.Browser.Actions.ClickButtonTest do
     end
   end
 
-  @tag :polling
   test "throws an error if the button cannot be found on the page", %{page: page} do
     assert_raise Wallabidi.QueryError, ~r/Expected (.*) 1/, fn ->
       click(page, button("unfound button", []))
@@ -292,8 +287,6 @@ defmodule Wallabidi.Integration.Browser.Actions.ClickButtonTest do
   test "escapes quotes", %{page: page} do
     assert click(page, button("I'm a button"))
   end
-
-  @tag :polling
 
   test "with duplicate buttons", %{page: page} do
     assert_raise Wallabidi.QueryError, ~r/Expected (.*) 1/, fn ->

--- a/integration_test/cases/browser/click_test.exs
+++ b/integration_test/cases/browser/click_test.exs
@@ -51,8 +51,6 @@ defmodule Wallabidi.Integration.Browser.ClickTest do
       assert selected?(page, Query.css("#option2"))
     end
 
-    @tag :polling
-
     test "throw an error if a label exists but does not have a for attribute", %{page: page} do
       bad_form =
         page
@@ -62,8 +60,6 @@ defmodule Wallabidi.Integration.Browser.ClickTest do
         click(bad_form, Query.radio_button("Radio with bad label"))
       end
     end
-
-    @tag :polling
 
     test "throw an error if the query matches multiple labels", %{page: page} do
       assert_raise Wallabidi.QueryError, ~r/Expected (.*) 1/, fn ->
@@ -94,8 +90,6 @@ defmodule Wallabidi.Integration.Browser.ClickTest do
     test "escapes quotes", %{page: page} do
       assert click(page, Query.checkbox("I'm a checkbox"))
     end
-
-    @tag :polling
 
     test "throw an error if a label exists but does not have a for attribute", %{page: page} do
       assert_raise Wallabidi.QueryError, fn ->

--- a/integration_test/cases/browser/fill_in_test.exs
+++ b/integration_test/cases/browser/fill_in_test.exs
@@ -62,15 +62,11 @@ defmodule Wallabidi.Integration.Browser.FillInTest do
            |> has_value?("Test Label Text")
   end
 
-  @tag :polling
-
   test "checks for labels without for attributes", %{page: page} do
     assert_raise Wallabidi.QueryError, ~r/label has no 'for'/, fn ->
       fill_in(page, Query.text_field("Input with bad label"), with: "Test")
     end
   end
-
-  @tag :polling
 
   test "checks for mismatched ids on labels", %{page: page} do
     assert_raise Wallabidi.QueryError,
@@ -80,8 +76,6 @@ defmodule Wallabidi.Integration.Browser.FillInTest do
                  end
   end
 
-  @tag :polling
-
   test "checks for duplicate ids on labels", %{page: page} do
     assert_raise Wallabidi.QueryError,
                  ~r/but the label's 'for' attribute\smatches 3 elements/,
@@ -90,7 +84,6 @@ defmodule Wallabidi.Integration.Browser.FillInTest do
                  end
   end
 
-  @tag :polling
   test "provides guidance for labels with type mismatch", %{page: page} do
     assert_raise Wallabidi.QueryError,
                  ~r/but the label's 'for' attribute\smatches one element/,

--- a/integration_test/cases/browser/find_test.exs
+++ b/integration_test/cases/browser/find_test.exs
@@ -41,15 +41,11 @@ defmodule Wallabidi.Integration.Browser.FindTest do
       assert List.first(users) |> Element.text() == "Chris"
     end
 
-    @tag :polling
-
     test "throws a not found error if the element could not be found", %{page: page} do
       assert_raise Wallabidi.QueryError, ~r/Expected to find/, fn ->
         find(page, Query.css("#not-there"))
       end
     end
-
-    @tag :polling
 
     test "throws a not found error if the xpath could not be found", %{page: page} do
       assert_raise Wallabidi.QueryError, ~r/Expected (.*) xpath '\/\/test-element'/, fn ->
@@ -57,15 +53,11 @@ defmodule Wallabidi.Integration.Browser.FindTest do
       end
     end
 
-    @tag :polling
-
     test "ambiguous queries raise an exception", %{page: page} do
       assert_raise Wallabidi.QueryError, ~r/Expected (.*) 1(.*) but 5/, fn ->
         find(page, Query.css(".user"))
       end
     end
-
-    @tag :polling
 
     test "throws errors if element should not be visible", %{page: page} do
       assert_raise Wallabidi.QueryError, ~r/invisible/, fn ->
@@ -74,7 +66,6 @@ defmodule Wallabidi.Integration.Browser.FindTest do
     end
 
     @tag :headless
-    @tag :polling
     test "find/2 raises an error if the element is not visible", %{session: session} do
       session
       |> visit("page_1.html")
@@ -146,8 +137,6 @@ defmodule Wallabidi.Integration.Browser.FindTest do
 
     assert find(session, Query.css(".orange", count: 5)) |> length == 5
   end
-
-  @tag :polling
 
   test "finding one or more elements", %{session: session} do
     session

--- a/integration_test/cases/browser/stale_nodes_test.exs
+++ b/integration_test/cases/browser/stale_nodes_test.exs
@@ -5,7 +5,6 @@ defmodule Wallabidi.Integration.Browser.StaleElementsTest do
 
   describe "when a DOM element becomes stale" do
     @tag :headless
-    @tag :polling
     test "the query is retried", %{session: session} do
       element =
         session
@@ -16,7 +15,6 @@ defmodule Wallabidi.Integration.Browser.StaleElementsTest do
     end
 
     @tag :headless
-    @tag :polling
     test "when a DOM element disappears", %{session: session} do
       element =
         session

--- a/integration_test/cases/browser/visible_test.exs
+++ b/integration_test/cases/browser/visible_test.exs
@@ -33,7 +33,6 @@ defmodule Wallabidi.Integration.Browser.VisibleTest do
     setup :visit_page
 
     # The `false` case waits the full max_wait_time before returning.
-    @tag :polling
     test "returns a boolean", %{page: page} do
       assert page
              |> visible?(Query.css("#visible")) == true

--- a/integration_test/cases/live_view/async_patch_test.exs
+++ b/integration_test/cases/live_view/async_patch_test.exs
@@ -39,7 +39,6 @@ defmodule Wallabidi.Integration.LiveView.AsyncPatchTest do
   end
 
   describe "phx-trigger-action" do
-    @tag :polling
     test "click on submit button awaits the full-page redirect", %{session: session} do
       # The click fires phx-submit, which flips trigger_action, which fires
       # a native POST to /trigger-action-target, which redirects to

--- a/integration_test/cases/live_view/slow_event_ack_test.exs
+++ b/integration_test/cases/live_view/slow_event_ack_test.exs
@@ -17,7 +17,6 @@ defmodule Wallabidi.Integration.LiveView.SlowEventAckTest do
 
   @base Application.compile_env(:wallabidi, :live_app_url, "http://localhost:4321")
 
-  @tag :polling
   test "click returns only after the server has acked the slow event",
        %{session: session} do
     # After the click, current_url should already be the destination. If

--- a/integration_test/cases/live_view_smoke/slow_event_test.exs
+++ b/integration_test/cases/live_view_smoke/slow_event_test.exs
@@ -6,7 +6,6 @@ defmodule Wallabidi.Integration.LiveViewSmoke.SlowEventTest do
   @base Application.compile_env(:wallabidi, :live_app_url, "http://localhost:4321")
 
   @tag :cross_lv_nav
-  @tag :polling
   test "click → 3s server work → push_navigate; assertion waits for full transition", %{
     session: session
   } do

--- a/integration_test/cases/live_view_smoke/trigger_action_test.exs
+++ b/integration_test/cases/live_view_smoke/trigger_action_test.exs
@@ -8,7 +8,6 @@ defmodule Wallabidi.Integration.LiveViewSmoke.TriggerActionTest do
   @tag :native_form_submit
   @tag :cross_lv_nav
   # Real validate→flip→submit→POST→redirect chain across two LV processes.
-  @tag :polling
   test "phx-trigger-action: validate → flip → native submit → POST → redirect", %{
     session: session
   } do

--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -87,7 +87,6 @@ defmodule Wallabidi.Integration.QueryTest do
 
   describe "filtering queries by visibility" do
     @tag :headless
-    @tag :polling
     test "finds elements that are invisible", %{session: session} do
       assert_raise Wallabidi.QueryError, fn ->
         session
@@ -114,8 +113,6 @@ defmodule Wallabidi.Integration.QueryTest do
       assert Enum.count(element) == 2
     end
   end
-
-  @tag :polling
 
   test "queries can check the number of elements", %{session: session} do
     assert_raise Wallabidi.QueryError, fn ->
@@ -158,8 +155,6 @@ defmodule Wallabidi.Integration.QueryTest do
                    |> Browser.find(Query.css(".user", at: 5))
                  end
   end
-
-  @tag :polling
 
   test "queries can specify element text", %{session: session} do
     assert_raise Wallabidi.QueryError, fn ->


### PR DESCRIPTION
## What

Removes 37 `@tag :polling` annotations across 15 integration test files.

## Why

The `:polling` tag was only ever consumed by `SlowTestGuard`, which was deleted in #37 (replaced by the event-driven-await regression detector). With the guard gone, the tag is **inert**:

- No `exclude`/`include` filter in `integration_test/cases/test_helper.exs` references it (excludes are `pending`, `live_view_only`, `cdp_only`, `bidi_unstable`, etc.).
- No `mix` alias passes `--only/--exclude polling`.
- No config references it.

So the tags do nothing — they're leftover noise that reads as if it still controls something. Removing them.

## Verification

- All 37 matches were standalone `@tag :polling` lines (none combined with other tags), so each was removed cleanly above its `test`.
- `mix format --check-formatted` passes; lib compiles.
- Ran de-tagged files on the LiveView lane (`slow_event_test`, `trigger_action_test`) → 2 tests, 0 failures, **and the await detector did not fire** (they pass on events, not timeouts) — confirming the tests run correctly without the tag.

No behaviour change. The event-driven-await detector now governs these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)