### PR TITLE
fix: replace Ecto.Repo.Registry.lookup with Process.whereis

### DIFF
--- a/lib/wallabidi/feature.ex
+++ b/lib/wallabidi/feature.ex
@@ -272,12 +272,7 @@ defmodule Wallabidi.Feature do
       end
 
       defp repo_started?(repo) do
-        case Ecto.Repo.Registry.lookup(repo) do
-          {_, _, _} -> true
-          _ -> false
-        end
-      rescue
-        _ -> false
+        not is_nil(Process.whereis(repo))
       end
 
       defp checkout_ecto_repos(repo, async) do


### PR DESCRIPTION
## What

`repo_started?/1` was pattern-matching `{_, _, _}` against `Ecto.Repo.Registry.lookup/1`, which returns a map. The match always failed, so every repo was treated as not started and sandbox checkout was skipped entirely.

## Why

`Ecto.Repo.Registry` is a private internal module. Using `Process.whereis/1` checks the same runtime condition — whether the repo supervisor is registered — using stable public OTP primitives.